### PR TITLE
Bump hwpe from f1d0b72 to v1.2

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -56,5 +56,5 @@ fpu_interco:
   domain: [soc, cluster]
   group: pulp-platform
 hwpe-mac-engine:
-  commit: f1d0b72
+  commit: v1.2
 


### PR DESCRIPTION
Bump hwpe to same version as in `pulp_soc`. Resolves dependency conflict.

Francesco Conti (6):
      Fixed control-related issue in mac_engine
      Merge commit 'b96687c'
      Introduced TCDM FIFOs
      small changes for verilator support
      Verilator-related changes
      Update README.md