### PR TITLE
:arrow_up: Upgrade 'fpu_interco' dependency

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -52,7 +52,7 @@ cluster_peripherals:
   domain: [cluster]
   group:  pulp-platform
 fpu_interco:
-  commit: tags/v1.2.4
+  commit: tags/v1.2.5
   domain: [soc, cluster]
   group: pulp-platform
 


### PR DESCRIPTION
* This fixes a bug where division / square root computations on the
shared divsqrt unit would treat fp16alt data as fp32.