### PR TITLE
Replace axi_slice_wrap with axi ip module

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -22,7 +22,7 @@ axi/axi_size_conv:
 axi/axi:
   commit: tags/v0.23.0
   domain: [soc]
-  group: recogni
+  group: pulp-platform 
 cluster_interconnect:
   commit: tags/v1.0.3
   domain: [cluster]

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,6 +19,10 @@ axi/axi_size_conv:
   commit: tags/pulp-v1.0
   domain: [cluster]
   group: pulp-platform
+axi/axi:
+  commit: tags/v0.23.0
+  domain: [soc]
+  group: recogni
 cluster_interconnect:
   commit: tags/v1.0.3
   domain: [cluster]

--- a/src_files.yml
+++ b/src_files.yml
@@ -21,7 +21,6 @@ pulp_cluster:
     rtl/dmac_wrap.sv,
     rtl/hwpe_subsystem.sv,
     rtl/cluster_bus_wrap.sv,
-    rtl/axi_slice_wrap.sv,
     rtl/axi2mem_wrap.sv,
     rtl/axi2per_wrap.sv,
     rtl/per2axi_wrap.sv,


### PR DESCRIPTION
Removes the axi_slice_wrap.sv file and uses the axi ip module instead to prevent conflicting definitions of axi_slice_wrap in projects that use both pulp_cluster and axi