### PR TITLE
Ibex integration

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -32,7 +32,7 @@ mchan:
   domain: [cluster]
   group: pulp-platform
 hier-icache:
-  commit: 0b2fad5e8f91cdcf5270637b246775bbdb613496
+  commit: v1.2.0
   domain: [cluster]
   group:  pulp-platform
 icache-intc:

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -32,7 +32,7 @@ mchan:
   domain: [cluster]
   group: pulp-platform
 hier-icache:
-  commit: marsellus_v1.2.0
+  commit: 0b2fad5e8f91cdcf5270637b246775bbdb613496
   domain: [cluster]
   group:  pulp-platform
 icache-intc:

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -93,24 +93,27 @@ module cluster_peripherals
   XBAR_PERIPH_BUS.Master              hwpe_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_sel_o,
-  output logic                        hwpe_en_o,
+  output logic                        hwpe_en_o
 
   //output logic [NB_L1_CUTS-1:0][RW_MARGIN_WIDTH-1:0] rw_margin_L1_o,
 
   // Control ports
 `ifdef PRIVATE_ICACHE
-     SP_ICACHE_CTRL_UNIT_BUS.Master       IC_ctrl_unit_bus_main[NB_CACHE_BANKS],
-     PRI_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus_pri[NB_CORES],
-     output logic [NB_CORES-1:0]          enable_l1_l15_prefetch_o
+  ,
+  SP_ICACHE_CTRL_UNIT_BUS.Master       IC_ctrl_unit_bus_main[NB_CACHE_BANKS],
+  PRI_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus_pri[NB_CORES],
+  output logic [NB_CORES-1:0]          enable_l1_l15_prefetch_o
 `else
   `ifdef SP_ICACHE
-      // Control ports
-      SP_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus[NB_CACHE_BANKS],
-      L0_CTRL_UNIT_BUS.Master             L0_ctrl_unit_bus[NB_CORES]
+    ,
+    // Control ports
+    SP_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus[NB_CACHE_BANKS],
+    L0_CTRL_UNIT_BUS.Master             L0_ctrl_unit_bus[NB_CORES]
   `else
-      `ifdef MP_ICACHE
-          MP_PF_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus
-      `endif
+    `ifdef MP_ICACHE
+      ,
+      MP_PF_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus
+    `endif
   `endif
 `endif
  

--- a/rtl/core_region.sv
+++ b/rtl/core_region.sv
@@ -213,7 +213,7 @@ module core_region
         .WAPUTYPE            ( WAPUTYPE          ),
         .DM_HaltAddress      ( DEBUG_START_ADDR + 16'h0800 )
 
-      ) CL_CORE (
+      ) RISCV_CORE (
         .clk_i                 ( clk_i             ),
         .rst_ni                ( rst_ni            ),
 
@@ -318,7 +318,7 @@ module core_region
         .SecureIbex               ( 1'b0              ),
         .DmHaltAddr               ( 32'h1A110800      ),
         .DmExceptionAddr          ( 32'h1A110808      )
-      ) CL_CORE (
+      ) IBEX_CORE (
         .clk_i                 ( clk_i              ),
         .rst_ni                ( rst_ni             ),
 

--- a/rtl/core_region.sv
+++ b/rtl/core_region.sv
@@ -34,72 +34,72 @@ module core_region
   // parameter USE_FPU             = 1,
   // parameter USE_HWPE            = 1,
   parameter N_EXT_PERF_COUNTERS = 1,
-  parameter CORE_ID            = 0,
-  parameter ADDR_WIDTH         = 32,
-  parameter DATA_WIDTH         = 32,
-  parameter INSTR_RDATA_WIDTH  = 32,
-  parameter CLUSTER_ALIAS_BASE = 12'h000,
-  parameter REMAP_ADDRESS      = 0,
+  parameter CORE_ID             = 0,
+  parameter ADDR_WIDTH          = 32,
+  parameter DATA_WIDTH          = 32,
+  parameter INSTR_RDATA_WIDTH   = 32,
+  parameter CLUSTER_ALIAS_BASE  = 12'h000,
+  parameter REMAP_ADDRESS       = 0,
 
-  parameter APU_NARGS_CPU      = 2,
-  parameter APU_WOP_CPU        = 1,
-  parameter WAPUTYPE           = 3,
-  parameter APU_NDSFLAGS_CPU   = 3,
-  parameter APU_NUSFLAGS_CPU   = 5,
+  parameter APU_NARGS_CPU       = 2,
+  parameter APU_WOP_CPU         = 1,
+  parameter WAPUTYPE            = 3,
+  parameter APU_NDSFLAGS_CPU    = 3,
+  parameter APU_NUSFLAGS_CPU    = 5,
   
-  parameter FPU                =  0,
-  parameter FP_DIVSQRT         =  0,
-  parameter SHARED_FP          =  0,
-  parameter SHARED_FP_DIVSQRT  =  0,
+  parameter FPU                 =  0,
+  parameter FP_DIVSQRT          =  0,
+  parameter SHARED_FP           =  0,
+  parameter SHARED_FP_DIVSQRT   =  0,
 
-  parameter DEBUG_START_ADDR   = `DEBUG_START_ADDR,
+  parameter DEBUG_START_ADDR    = `DEBUG_START_ADDR,
 
-  parameter L2_SLM_FILE   = "./slm_files/l2_stim.slm",
-  parameter ROM_SLM_FILE  = "../sw/apps/boot/slm_files/l2_stim.slm"
+  parameter L2_SLM_FILE         = "./slm_files/l2_stim.slm",
+  parameter ROM_SLM_FILE        = "../sw/apps/boot/slm_files/l2_stim.slm"
 )
 (
-  input logic 			      clk_i,
-  input logic 			      rst_ni,
-  input logic 			      init_ni,
+  input logic                            clk_i,
+  input logic                            rst_ni,
+  input logic                            init_ni,
 
-  input logic [3:0] 		      base_addr_i, // FOR CLUSTER VIRTUALIZATION
+  input logic [3:0]                      base_addr_i, // FOR CLUSTER VIRTUALIZATION
 
-  input logic [5:0] 		      cluster_id_i,
+  input logic [5:0]                      cluster_id_i,
   
-  input logic 			      irq_req_i,
-  output logic 			      irq_ack_o,
-  input logic [4:0] 		      irq_id_i,
-  output logic [4:0] 		      irq_ack_id_o,
+  input logic                            irq_req_i,
+  output logic                           irq_ack_o,
+  input logic [4:0]                      irq_id_i,
+  output logic [4:0]                     irq_ack_id_o,
   
-  input logic 			      clock_en_i,
-  input logic 			      fetch_en_i,
-  input logic 			      fregfile_disable_i,
+  input logic                            clock_en_i,
+  input logic                            fetch_en_i,
+  input logic                            fregfile_disable_i,
 
-  input logic [31:0] 		      boot_addr_i,
+  input logic [31:0]                     boot_addr_i,
 
-  input logic 			      test_mode_i,
+  input logic                            test_mode_i,
 
-  output logic 			      core_busy_o,
+  output logic                           core_busy_o,
 
   // Interface to Instruction Logarithmic interconnect (Req->grant handshake)
-  output logic 			      instr_req_o,
-  input logic 			      instr_gnt_i,
-  output logic [31:0] 		      instr_addr_o,
-  input logic [INSTR_RDATA_WIDTH-1:0] instr_r_rdata_i,
-  input logic 			      instr_r_valid_i,
+  output logic                           instr_req_o,
+  input logic                            instr_gnt_i,
+  output logic [31:0]                    instr_addr_o,
+  input logic [INSTR_RDATA_WIDTH-1:0]    instr_r_rdata_i,
+  input logic                            instr_r_valid_i,
 
-  input logic             debug_req_i,
-				      
-				      //XBAR_TCDM_BUS.Slave debug_bus,
-  //output logic 			      debug_core_halted_o,
-  //input logic 			      debug_core_halt_i,
-  //input logic 			      debug_core_resume_i,
-				      
-				      // Interface for DEMUX to TCDM INTERCONNECT ,PERIPHERAL INTERCONNECT and DMA CONTROLLER
-				      XBAR_TCDM_BUS.Master tcdm_data_master,
-				      //XBAR_TCDM_BUS.Master dma_ctrl_master,
-				      XBAR_PERIPH_BUS.Master eu_ctrl_master,
-				      XBAR_PERIPH_BUS.Master periph_data_master
+  input logic                            debug_req_i,
+              
+              //XBAR_TCDM_BUS.Slave debug_bus,
+  //output logic            debug_core_halted_o,
+  //input logic             debug_core_halt_i,
+  //input logic             debug_core_resume_i,
+              
+  // Interface for DEMUX to TCDM INTERCONNECT ,PERIPHERAL INTERCONNECT and DMA CONTROLLER
+  XBAR_TCDM_BUS.Master                   tcdm_data_master,
+  //XBAR_TCDM_BUS.Master dma_ctrl_master,
+  XBAR_PERIPH_BUS.Master                 eu_ctrl_master,
+  XBAR_PERIPH_BUS.Master                 periph_data_master
 
 
  // new interface signals
@@ -161,15 +161,15 @@ module core_region
    logic                     apu_master_req_o;
    logic                     apu_master_gnt_i;
    // request channel
-   logic [WAPUTYPE-1:0]            apu_master_type_o;
-   logic [APU_NARGS_CPU-1:0][31:0] apu_master_operands_o;
-   logic [APU_WOP_CPU-1:0]     apu_master_op_o;
-   logic [APU_NDSFLAGS_CPU-1:0]    apu_master_flags_o;
+   logic [WAPUTYPE-1:0]             apu_master_type_o;
+   logic [APU_NARGS_CPU-1:0][31:0]  apu_master_operands_o;
+   logic [APU_WOP_CPU-1:0]          apu_master_op_o;
+   logic [APU_NDSFLAGS_CPU-1:0]     apu_master_flags_o;
    // response channel
-   logic         apu_master_ready_o;
-   logic         apu_master_valid_i;
-   logic [31:0]        apu_master_result_i;
-   logic [APU_NUSFLAGS_CPU-1:0]    apu_master_flags_i;
+   logic                        apu_master_ready_o;
+   logic                        apu_master_valid_i;
+   logic [31:0]                 apu_master_result_i;
+   logic [APU_NUSFLAGS_CPU-1:0] apu_master_flags_i;
 
    assign apu_master_gnt_i      = '1;
    assign apu_master_valid_i    = '0;

--- a/rtl/instr_width_converter.sv
+++ b/rtl/instr_width_converter.sv
@@ -1,0 +1,71 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+// 
+// Converts 128-bit instruction data from cache to 32-bit instruction data for core.
+
+module instr_width_converter (
+  input logic             clk_i,
+  input logic             rst_ni,
+
+  output logic            cache_req_o,
+  input logic             cache_gnt_i,
+  output logic [31:0]     cache_addr_o,
+  input logic [127:0]     cache_r_rdata_i,
+  input logic             cache_r_valid_i,
+
+  input logic             core_req_i,
+  output logic            core_gnt_o,
+  input logic [31:0]      core_addr_i,
+  output logic [31:0]     core_r_rdata_o,
+  output logic            core_r_valid_o
+  );
+
+  logic       busy_d, busy_q;
+  logic       cache_req_gnt;
+  logic [1:0] word_sel_d, word_sel_q;
+  logic [1:0] unused_addr;
+
+  assign cache_req_gnt  = cache_req_o && cache_gnt_i;
+  assign core_gnt_o     = cache_req_gnt;
+  assign cache_req_o    = cache_r_valid_i && busy_q ? core_req_i :              // request passes if old instruction is available
+                                             busy_q ? 1'b0       : core_req_i;  // or not processing any new instructions
+
+  assign cache_addr_o = {core_addr_i[31:4], 4'b0000};
+  assign unused_addr  = core_addr_i[1:0];
+
+  assign busy_d =   cache_req_gnt ? 1'b1 : 
+                  cache_r_valid_i ? 1'b0 : busy_q;                    // Core will be busy if request is granted and not available yet
+
+  assign word_sel_d = cache_req_gnt ? core_addr_i[3:2] : word_sel_q;  // Select address portion based on previous request
+
+  always_comb begin : mux_r_data
+    unique case (word_sel_q)
+      2'b00   : core_r_rdata_o = cache_r_rdata_i[31:0];
+      2'b01   : core_r_rdata_o = cache_r_rdata_i[63:32];
+      2'b10   : core_r_rdata_o = cache_r_rdata_i[95:64];
+      2'b11   : core_r_rdata_o = cache_r_rdata_i[127:96];
+      default : core_r_rdata_o = cache_r_rdata_i[31:0];
+    endcase // word_sel_q
+  end
+
+  assign core_r_valid_o = cache_r_valid_i;
+
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_control
+    if(~rst_ni) begin
+      busy_q      <= 1'b0;
+      word_sel_q  <= '0;
+    end else begin
+      busy_q      <= busy_d;
+      word_sel_q  <= word_sel_d;
+    end
+  end
+
+endmodule

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -33,16 +33,16 @@ module pulp_cluster
   parameter NB_MPERIPHS             = NB_MPERIPHS,
   parameter NB_SPERIPHS             = NB_SPERIPHS,
   
-  parameter CLUSTER_ALIAS_BASE = 12'h000,
+  parameter CLUSTER_ALIAS_BASE      = 12'h000,
   
-  parameter TCDM_SIZE          = 64*1024,                 // [B], must be 2**N
-  parameter NB_TCDM_BANKS      = 16,                      // must be 2**N
-  parameter TCDM_BANK_SIZE     = TCDM_SIZE/NB_TCDM_BANKS, // [B]
-  parameter TCDM_NUM_ROWS      = TCDM_BANK_SIZE/4,        // [words]
-  parameter HWPE_PRESENT       = 1,                       // set to 1 if HW Processing Engines are present in the cluster
+  parameter TCDM_SIZE               = 64*1024,                 // [B], must be 2**N
+  parameter NB_TCDM_BANKS           = 16,                      // must be 2**N
+  parameter TCDM_BANK_SIZE          = TCDM_SIZE/NB_TCDM_BANKS, // [B]
+  parameter TCDM_NUM_ROWS           = TCDM_BANK_SIZE/4,        // [words]
+  parameter HWPE_PRESENT            = 1,                       // set to 1 if HW Processing Engines are present in the cluster
 
   // I$ parameters
-  parameter SET_ASSOCIATIVE       = 4,
+  parameter SET_ASSOCIATIVE         = 4,
 `ifdef PRIVATE_ICACHE
     parameter NB_CACHE_BANKS        = 2,
 `endif
@@ -54,20 +54,20 @@ module pulp_cluster
 `ifdef SP_ICACHE
     parameter NB_CACHE_BANKS        = 8,
 `endif
-  parameter CACHE_LINE            = 1,
-  parameter CACHE_SIZE            = 4096,
-  parameter ICACHE_DATA_WIDTH     = 128,
-  parameter L0_BUFFER_FEATURE     = "DISABLED",
-  parameter MULTICAST_FEATURE     = "DISABLED",
-  parameter SHARED_ICACHE         = "ENABLED",
-  parameter DIRECT_MAPPED_FEATURE = "DISABLED",
-  parameter L2_SIZE               = 512*1024,
-  parameter USE_REDUCED_TAG       = "TRUE",
+  parameter CACHE_LINE              = 1,
+  parameter CACHE_SIZE              = 4096,
+  parameter ICACHE_DATA_WIDTH       = 128,
+  parameter L0_BUFFER_FEATURE       = "DISABLED",
+  parameter MULTICAST_FEATURE       = "DISABLED",
+  parameter SHARED_ICACHE           = "ENABLED",
+  parameter DIRECT_MAPPED_FEATURE   = "DISABLED",
+  parameter L2_SIZE                 = 512*1024,
+  parameter USE_REDUCED_TAG         = "TRUE",
 
   // core parameters
-  parameter ROM_BOOT_ADDR     = 32'h1A000000,
-  parameter BOOT_ADDR         = 32'h1C000000,
-  parameter INSTR_RDATA_WIDTH = 128,
+  parameter ROM_BOOT_ADDR           = 32'h1A000000,
+  parameter BOOT_ADDR               = 32'h1C000000,
+  parameter INSTR_RDATA_WIDTH       = 128,
 
   parameter CLUST_FPU               = 1,
   parameter CLUST_FP_DIVSQRT        = 1,
@@ -75,42 +75,42 @@ module pulp_cluster
   parameter CLUST_SHARED_FP_DIVSQRT = 2,
   
   // AXI parameters
-  parameter AXI_ADDR_WIDTH        = 32,
-  parameter AXI_DATA_C2S_WIDTH    = 64,
-  parameter AXI_DATA_S2C_WIDTH    = 32,
-  parameter AXI_USER_WIDTH        = 6,
-  parameter AXI_ID_IN_WIDTH       = 4,
-  parameter AXI_ID_OUT_WIDTH      = 6, 
-  parameter AXI_STRB_C2S_WIDTH    = AXI_DATA_C2S_WIDTH/8,
-  parameter AXI_STRB_S2C_WIDTH    = AXI_DATA_S2C_WIDTH/8,
-  parameter DC_SLICE_BUFFER_WIDTH = 8,
+  parameter AXI_ADDR_WIDTH          = 32,
+  parameter AXI_DATA_C2S_WIDTH      = 64,
+  parameter AXI_DATA_S2C_WIDTH      = 32,
+  parameter AXI_USER_WIDTH          = 6,
+  parameter AXI_ID_IN_WIDTH         = 4,
+  parameter AXI_ID_OUT_WIDTH        = 6, 
+  parameter AXI_STRB_C2S_WIDTH      = AXI_DATA_C2S_WIDTH/8,
+  parameter AXI_STRB_S2C_WIDTH      = AXI_DATA_S2C_WIDTH/8,
+  parameter DC_SLICE_BUFFER_WIDTH   = 8,
   
   // TCDM and log interconnect parameters
-  parameter DATA_WIDTH     = 32,
-  parameter ADDR_WIDTH     = 32,
-  parameter BE_WIDTH       = DATA_WIDTH/8,
-  parameter TEST_SET_BIT   = 20,                       // bit used to indicate a test-and-set operation during a load in TCDM
-  parameter ADDR_MEM_WIDTH = $clog2(TCDM_BANK_SIZE/4), // WORD address width per TCDM bank (the word width is 32 bits)
+  parameter DATA_WIDTH              = 32,
+  parameter ADDR_WIDTH              = 32,
+  parameter BE_WIDTH                = DATA_WIDTH/8,
+  parameter TEST_SET_BIT            = 20,                       // bit used to indicate a test-and-set operation during a load in TCDM
+  parameter ADDR_MEM_WIDTH          = $clog2(TCDM_BANK_SIZE/4), // WORD address width per TCDM bank (the word width is 32 bits)
   
   // DMA parameters
-  parameter TCDM_ADD_WIDTH     = ADDR_MEM_WIDTH + $clog2(NB_TCDM_BANKS) + 2, // BYTE address width TCDM
-  parameter NB_OUTSND_BURSTS   = 8,
-  parameter MCHAN_BURST_LENGTH = 256,
+  parameter TCDM_ADD_WIDTH          = ADDR_MEM_WIDTH + $clog2(NB_TCDM_BANKS) + 2, // BYTE address width TCDM
+  parameter NB_OUTSND_BURSTS        = 8,
+  parameter MCHAN_BURST_LENGTH      = 256,
 
 
   // peripheral and periph interconnect parameters
-  parameter LOG_CLUSTER    = 5,  // unused
-  parameter PE_ROUTING_LSB = 10, // LSB used as routing BIT in periph interco
-  //parameter PE_ROUTING_MSB = 13, // MSB used as routing BIT in periph interco
-  parameter EVNT_WIDTH     = 8,  // size of the event bus
-  parameter REMAP_ADDRESS  = 1,   // for cluster virtualization
+  parameter LOG_CLUSTER             = 5,  // unused
+  parameter PE_ROUTING_LSB          = 10, // LSB used as routing BIT in periph interco
+  // parameter PE_ROUTING_MSB          = 13, // MSB used as routing BIT in periph interco
+  parameter EVNT_WIDTH              = 8,  // size of the event bus
+  parameter REMAP_ADDRESS           = 1,  // for cluster virtualization
 
   // FPU PARAMETERS
-  parameter APU_NARGS_CPU         = 3,
-  parameter APU_WOP_CPU           = 6,
-  parameter WAPUTYPE              = 3,
-  parameter APU_NDSFLAGS_CPU      = 15,
-  parameter APU_NUSFLAGS_CPU      = 5
+  parameter APU_NARGS_CPU           = 3,
+  parameter APU_WOP_CPU             = 6,
+  parameter WAPUTYPE                = 3,
+  parameter APU_NDSFLAGS_CPU        = 15,
+  parameter APU_NUSFLAGS_CPU        = 5
 )
 (
   input  logic                             clk_i,
@@ -146,7 +146,7 @@ module pulp_cluster
   input  logic                             pf_evt_ack_i,
   output logic                             pf_evt_valid_o,
 
-  input logic  [NB_CORES-1:0]               dbg_irq_valid_i,
+  input logic  [NB_CORES-1:0]              dbg_irq_valid_i,
    
   // AXI4 SLAVE
   //***************************************
@@ -285,17 +285,17 @@ module pulp_cluster
   logic                               s_hwpe_sel;
   logic                               s_hwpe_en;
 
-  logic                s_cluster_periphs_busy;
-  logic                s_axi2mem_busy;
-  logic                s_per2axi_busy;
-  logic                s_axi2per_busy;
-  logic                s_dmac_busy;
-  logic                s_cluster_cg_en;
-  logic [NB_CORES-1:0] s_dma_event;
-  logic [NB_CORES-1:0] s_dma_irq;
-  logic [NB_CORES-1:0][3:0]  s_hwpe_remap_evt;
-  logic [NB_CORES-1:0][1:0]  s_hwpe_evt;
-  logic                      s_hwpe_busy;
+  logic                     s_cluster_periphs_busy;
+  logic                     s_axi2mem_busy;
+  logic                     s_per2axi_busy;
+  logic                     s_axi2per_busy;
+  logic                     s_dmac_busy;
+  logic                     s_cluster_cg_en;
+  logic [NB_CORES-1:0]      s_dma_event;
+  logic [NB_CORES-1:0]      s_dma_irq;
+  logic [NB_CORES-1:0][3:0] s_hwpe_remap_evt;
+  logic [NB_CORES-1:0][1:0] s_hwpe_evt;
+  logic                     s_hwpe_busy;
 
   logic [NB_CORES-1:0]               clk_core_en;
   logic                              clk_cluster;
@@ -875,10 +875,10 @@ module pulp_cluster
        
         .boot_addr_i         ( boot_addr[i]          ),
         .irq_id_i            ( irq_id[i]             ),
-	      .irq_ack_id_o        ( irq_ack_id[i]         ),
+        .irq_ack_id_o        ( irq_ack_id[i]         ),
         .irq_req_i           ( irq_req[i]            ),
         .irq_ack_o           ( irq_ack[i]            ),
-	
+  
         .test_mode_i         ( test_mode_i           ),
         .core_busy_o         ( core_busy[i]          ),
 
@@ -955,7 +955,7 @@ module pulp_cluster
    //**** Shared FPU cluster - Shared execution units ***
    //****************************************************
 
-  `ifdef SHARED_FPU_CLUSTER
+`ifdef SHARED_FPU_CLUSTER
 
       // request channel
       logic [NB_CORES-1:0][2:0][31:0]                s_apu__operands;
@@ -983,7 +983,7 @@ module pulp_cluster
          .FP_TYPE_WIDTH    ( 3                 ),
 
          .NB_CORE_ARGS      ( 3                ),
-	       .CORE_DATA_WIDTH   ( 32               ),
+         .CORE_DATA_WIDTH   ( 32               ),
          .CORE_OPCODE_WIDTH ( 6                ),
          .CORE_DSFLAGS_CPU  ( 15               ),
          .CORE_USFLAGS_CPU  ( 5                ),
@@ -1013,7 +1013,7 @@ module pulp_cluster
       (
          .clk                   ( clk_cluster                               ),
          .rst_n                 ( s_rst_n                                   ),
-	       .test_mode_i           ( test_mode_i                               ),
+         .test_mode_i           ( test_mode_i                               ),
          .core_slave_req_i      ( s_apu_master_req                          ),
          .core_slave_gnt_o      ( s_apu_master_gnt                          ),
          .core_slave_type_i     ( s_apu__type                               ),
@@ -1025,7 +1025,7 @@ module pulp_cluster
          .core_slave_rdata_o    ( s_apu_master_rdata                        ),
          .core_slave_rflags_o   ( s_apu__rflags                             )
       );
-  `endif
+`endif
 
   //**************************************************************
   //**** HW Processing Engines / Cluster-Coupled Accelerators ****
@@ -1173,7 +1173,7 @@ module pulp_cluster
 );
 
 `else
- `ifdef MP_ICACHE
+  `ifdef MP_ICACHE
   /* instruction cache */
   icache_top_mp_128_PF #(
     .FETCH_ADDR_WIDTH ( 32                 ),
@@ -1245,8 +1245,8 @@ module pulp_cluster
     .IC_ctrl_unit_slave_if  ( IC_ctrl_unit_bus           )
   );
 
-   `else
-      `ifdef SP_ICACHE
+  `else
+    `ifdef SP_ICACHE
          localparam NB_BANKS_SP   = NB_CORES;
          localparam CACHE_LINE_SP = 1;
          icache_top
@@ -1369,8 +1369,8 @@ module pulp_cluster
              .IC_ctrl_unit_slave_if  ( IC_ctrl_unit_bus        ),
              .L0_ctrl_unit_slave_if  ( L0_ctrl_unit_bus        )
          );
-      `endif // Closes `ifdef SP_ICACHE
-   `endif // Closes `ifdef MP_ICACHE
+    `endif // Closes `ifdef SP_ICACHE
+  `endif // Closes `ifdef MP_ICACHE
 `endif // Closes `ifdef PRI_ICACHE
 
 

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -26,11 +26,12 @@ import pulp_cluster_package::*;
 module pulp_cluster
 #(
   // cluster parameters
-  parameter NB_CORES           = 8,
-  parameter NB_HWPE_PORTS      = 4,
-  parameter NB_DMAS            = 4,
-  parameter NB_MPERIPHS        = NB_MPERIPHS,
-  parameter NB_SPERIPHS        = NB_SPERIPHS,
+  parameter CORE_TYPE_CL            = 0, // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
+  parameter NB_CORES                = 8,
+  parameter NB_HWPE_PORTS           = 4,
+  parameter NB_DMAS                 = 4,
+  parameter NB_MPERIPHS             = NB_MPERIPHS,
+  parameter NB_SPERIPHS             = NB_SPERIPHS,
   
   parameter CLUSTER_ALIAS_BASE = 12'h000,
   
@@ -843,6 +844,7 @@ module pulp_cluster
 
 
       core_region #(
+        .CORE_TYPE_CL        ( CORE_TYPE_CL       ),
         .CORE_ID             ( i                  ),
         .ADDR_WIDTH          ( 32                 ),
         .DATA_WIDTH          ( 32                 ),

--- a/src_files.yml
+++ b/src_files.yml
@@ -8,6 +8,7 @@ pulp_cluster:
   ]
   files: [
     packages/pulp_cluster_package.sv,
+    rtl/instr_width_converter.sv,
     rtl/core_region.sv,
     rtl/core_demux.sv,
     rtl/cluster_interconnect_wrap.sv,


### PR DESCRIPTION
This is an initial placement of the ibex core into the pulp cluster. It should not affect the cluster using riscv core. The hier-icache interface was updated to a commit on the fix_icache branch to allow for 32-bit instructions. Ibex has not been fully tested yet due to the SDK not allowing for this yet, but work is in progress.