### PR TITLE
Heterogeneous Cluster Interconnect in cluster

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   hier-icache:          { git: "git@github.com:pulp-platform/hier-icache.git", version: 1.2.0 }
   icache_mp_128_pf:     { git: "git@github.com:pulp-platform/icache_mp_128_pf.git", rev: "6f2e54102001230db9c82432bf9e011842419a48" }
   icache_private:       { git: "git@github.com:pulp-platform/icache_private.git", rev: "1d4cdbcbec3ab454c09d378fc55631b60450fccd" }
-  cluster_peripherals:  { git: "git@github.com:pulp-platform/cluster_peripherals.git", version: 2.0.0 }
+  cluster_peripherals:  { git: "git@github.com:pulp-platform/cluster_peripherals.git", version: 2.1.0 }
   fpu_interco:          { git: "git@github.com:pulp-platform/fpu_interco.git", rev: "83c7a1b690bffd006d8b925805aab3c1f8ba9ff1" }
   axi:                  { git: "git@github.com:pulp-platform/axi.git", version: 0.7.1 } # to be updated (now 0.24?)
   axi_node:             { git: "git@github.com:pulp-platform/axi_node.git", version: 1.1.4 } # deprecated, replaced by axi_xbar (in axi repo)
@@ -29,9 +29,7 @@ dependencies:
   riscv:                { git: "git@github.com:micprog/cv32e40p.git", rev: "pulpissimo-v3.4.1"} # To be updated to openhwgroup repository
   ibex:                 { git: "git@github.com:lowRISC/ibex.git", rev: "b148f3af51066ac3537c7c6eb4acbc17004bf868" }
   scm:                  { git: "git@github.com:pulp-platform/scm.git", version: 1.0.1}
-  hwpe-mac-engine:      { git: "git@github.com:micprog/hwpe-mac-engine.git", rev: "v1.2-bender" } # To be updated with pulp-platform dependency
-  # apu_cluster ?
-  # sp_icache ?
+  hwpe-datamover-example: { git: "https://github.com:pulp-platform/hwpe-datamover-example.git", version: 1.0 }
 
 sources:
     # Source files grouped in levels. Files in level 0 have no dependencies on files in this

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -52,15 +52,15 @@ hwpe-ctrl:
   group: pulp-platform
   domain: [soc, cluster, pulp]
 hwpe-stream:
-  commit: master
+  commit: v1.6.1
   group: pulp-platform
   domain: [soc, cluster, pulp]
 hci:
-  commit: add-no-hwpe-case
+  commit: v1.0.6
   group: pulp-platform
   domain: [cluster, pulp]
 cluster_peripherals:
-  commit: hci-ctrl-integration
+  commit: v1.0.2
   domain: [cluster]
   group:  pulp-platform
 fpu_interco:
@@ -68,7 +68,7 @@ fpu_interco:
   domain: [soc, cluster]
   group: pulp-platform
 hwpe-datamover-example:
-  commit: main
+  commit: v1.0
   group: pulp-platform
   domain: [cluster, pulp]
 

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -47,28 +47,29 @@ icache_private:
   commit: 1d4cdbcbec3ab454c09d378fc55631b60450fccd
   domain: [cluster]
   group:  pulp-platform
-cluster_peripherals:
-  commit: v2.0.0
-  domain: [cluster]
-  group:  pulp-platform
-fpu_interco:
-  commit: be7808b84a1dcdb1ecdb6e40814cc4864acd9451
-  domain: [soc, cluster]
-  group:  pulp-platform
 hwpe-ctrl:
   commit: v1.5
   group: pulp-platform
   domain: [soc, cluster, pulp]
 hwpe-stream:
-  commit: a3e3607
+  commit: master
   group: pulp-platform
   domain: [soc, cluster, pulp]
 hci:
-  commit: v1.0.3
+  commit: add-no-hwpe-case
   group: pulp-platform
   domain: [cluster, pulp]
-rbe:
-  commit: verification
-  group: pulp-restricted
-  server: git@iis-git.ee.ethz.ch
+cluster_peripherals:
+  commit: hci-ctrl-integration
+  domain: [cluster]
+  group:  pulp-platform
+fpu_interco:
+  commit: be7808b84a1dcdb1ecdb6e40814cc4864acd9451
+  domain: [soc, cluster]
+  group: pulp-platform
+hwpe-datamover-example:
+  commit: main
+  group: pulp-platform
+  domain: [cluster, pulp]
+
   

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -52,8 +52,23 @@ cluster_peripherals:
   domain: [cluster]
   group:  pulp-platform
 fpu_interco:
-  commit: 83c7a1b690bffd006d8b925805aab3c1f8ba9ff1
+  commit: be7808b84a1dcdb1ecdb6e40814cc4864acd9451
   domain: [soc, cluster]
   group:  pulp-platform
-
-
+hwpe-ctrl:
+  commit: v1.5
+  group: pulp-platform
+  domain: [soc, cluster, pulp]
+hwpe-stream:
+  commit: a3e3607
+  group: pulp-platform
+  domain: [soc, cluster, pulp]
+hci:
+  commit: v1.0.3
+  group: pulp-platform
+  domain: [cluster, pulp]
+rbe:
+  commit: verification
+  group: pulp-restricted
+  server: git@iis-git.ee.ethz.ch
+  

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -60,7 +60,7 @@ hci:
   group: pulp-platform
   domain: [cluster, pulp]
 cluster_peripherals:
-  commit: v1.0.2
+  commit: v2.1.0
   domain: [cluster]
   group:  pulp-platform
 fpu_interco:

--- a/rtl/axi2mem_wrap.sv
+++ b/rtl/axi2mem_wrap.sv
@@ -29,7 +29,7 @@ module axi2mem_wrap
   input logic          rst_ni,
   input logic          test_en_i,
   AXI_BUS.Slave        axi_slave,
-  XBAR_TCDM_BUS.Master tcdm_master[NB_DMAS-1:0],
+  hci_core_intf.master tcdm_master[NB_DMAS-1:0],
   output logic         busy_o
 );
 
@@ -46,13 +46,15 @@ module axi2mem_wrap
     for (genvar i=0; i<NB_DMAS; i++) begin : TCDM_BIND
       assign tcdm_master[i].add    = s_tcdm_bus_add[i];
       assign tcdm_master[i].req    = s_tcdm_bus_req[i];
-      assign tcdm_master[i].wdata  = s_tcdm_bus_wdata[i];
+      assign tcdm_master[i].data   = s_tcdm_bus_wdata[i];
       assign tcdm_master[i].wen    = s_tcdm_bus_wen[i];
       assign tcdm_master[i].be     = s_tcdm_bus_be[i];
+      assign tcdm_master[i].boffs  = '0;
+      assign tcdm_master[i].lrdy   = '1;
 
       assign s_tcdm_bus_gnt[i]     = tcdm_master[i].gnt;
       assign s_tcdm_bus_r_valid[i] = tcdm_master[i].r_valid;
-      assign s_tcdm_bus_r_rdata[i] = tcdm_master[i].r_rdata;
+      assign s_tcdm_bus_r_rdata[i] = tcdm_master[i].r_data;
     end
   endgenerate
 

--- a/rtl/cluster_interconnect_wrap.sv
+++ b/rtl/cluster_interconnect_wrap.sv
@@ -37,7 +37,9 @@ module cluster_interconnect_wrap
   parameter LOG_CLUSTER     = 5,
   parameter PE_ROUTING_LSB  = 16,
   parameter PE_ROUTING_MSB  = PE_ROUTING_LSB+$clog2(NB_SPERIPHS)-1, //differ
-  parameter CLUSTER_ALIAS_BASE = 12'h000
+  parameter CLUSTER_ALIAS_BASE = 12'h000,
+
+  parameter USE_HETEROGENEOUS_INTERCONNECT = 1
 )
 (
   input logic                          clk_i,
@@ -149,32 +151,102 @@ module cluster_interconnect_wrap
   //-*********** HETEROGENEOUS INTERCONNECT TO TCDM *********
   //-********************************************************
   // Wraps the Logarithmic Interconnect + a HWPE Interconnect
-  hci_interconnect #(
-    .N_HWPE ( 1                ),
-    .N_CORE ( NB_CORES         ),
-    .N_DMA  ( NB_DMAS          ),
-    .N_EXT  ( 4                ),
-    .N_MEM  ( NB_TCDM_BANKS    ),
-    .IW     ( TCDM_ID_WIDTH    ),
-    .AWC    ( ADDR_WIDTH       ),
-    .DW_LIC ( DATA_WIDTH       ),
-    .DW_SIC ( NB_HWPE_PORTS*32 ),
-    .TS_BIT ( TEST_SET_BIT     ),
-    .AWH    ( 32               ),
-    .DWH    ( 288              ),
-    .OWH    ( 1                ),
-    .AWM    ( ADDR_MEM_WIDTH+2 )
-  ) i_hci_interconnect (
-    .clk_i  ( clk_i               ),
-    .rst_ni ( rst_ni              ),
-    .clear_i( 1'b0                ),
-    .ctrl_i ( hci_ctrl_i          ),
-    .cores  ( core_tcdm_slave     ),
-    .hwpe   ( hwpe_tcdm_slave [0] ),
-    .dma    ( dma_slave           ),
-    .ext    ( ext_slave           ),
-    .mems   ( tcdm_sram_master    )
-  );
+  generate
+    if(USE_HETEROGENEOUS_INTERCONNECT) begin : hci_gen
+
+      hci_interconnect #(
+        .N_HWPE ( 1                ),
+        .N_CORE ( NB_CORES         ),
+        .N_DMA  ( NB_DMAS          ),
+        .N_EXT  ( 4                ),
+        .N_MEM  ( NB_TCDM_BANKS    ),
+        .IW     ( TCDM_ID_WIDTH    ),
+        .AWC    ( ADDR_WIDTH       ),
+        .DW_LIC ( DATA_WIDTH       ),
+        .DW_SIC ( NB_HWPE_PORTS*32 ),
+        .TS_BIT ( TEST_SET_BIT     ),
+        .AWH    ( 32               ),
+        .DWH    ( 288              ),
+        .OWH    ( 1                ),
+        .AWM    ( ADDR_MEM_WIDTH+2 )
+      ) i_hci_interconnect (
+        .clk_i  ( clk_i               ),
+        .rst_ni ( rst_ni              ),
+        .clear_i( 1'b0                ),
+        .ctrl_i ( hci_ctrl_i          ),
+        .cores  ( core_tcdm_slave     ),
+        .hwpe   ( hwpe_tcdm_slave [0] ),
+        .dma    ( dma_slave           ),
+        .ext    ( ext_slave           ),
+        .mems   ( tcdm_sram_master    )
+      );
+
+    end
+    else begin : no_hci_gen
+
+      hci_core_intf #(
+        .DW ( 32 ),
+        .AW ( 32 ),
+        .OW ( 1  )
+      ) core_hwpe_tcdm_slave [NB_CORES+NB_HWPE_PORTS-1:0] (
+        .clk ( clk_i )
+      );
+
+      hci_core_intf #(
+        .DW ( NB_HWPE_PORTS*32 ),
+        .AW ( 32               ),
+        .OW ( 1                )
+      ) null_hwpe_tcdm_slave (
+        .clk ( clk_i )
+      );
+
+      hci_core_split #(
+        .DW          ( NB_HWPE_PORTS*32 ),
+        .NB_OUT_CHAN ( NB_HWPE_PORTS    )
+      ) i_hwpe_tcdm_splitter (
+        .clk_i       ( clk_i                                                   ),
+        .rst_ni      ( rst_ni                                                  ),
+        .clear_i     ( clear_i                                                 ),
+        .tcdm_slave  ( hwpe_tcdm_slave[0]                                      ),
+        .tcdm_master ( core_hwpe_tcdm_slave[NB_CORES+NB_HWPE_PORTS-1:NB_CORES] )
+      );
+  
+      for(genvar ii=0; ii<NB_CORES; ii++) begin : core_tcdm_slave_gen
+        hci_core_assign i_assign (
+          .tcdm_slave  ( core_tcdm_slave      [ii] ),
+          .tcdm_master ( core_hwpe_tcdm_slave [ii] )
+        );
+      end
+
+      hci_interconnect #(
+        .N_HWPE ( 0                      ),
+        .N_CORE ( NB_CORES+NB_HWPE_PORTS ),
+        .N_DMA  ( NB_DMAS                ),
+        .N_EXT  ( 4                      ),
+        .N_MEM  ( NB_TCDM_BANKS          ),
+        .IW     ( TCDM_ID_WIDTH          ),
+        .AWC    ( ADDR_WIDTH             ),
+        .DW_LIC ( DATA_WIDTH             ),
+        .DW_SIC ( NB_HWPE_PORTS*32       ),
+        .TS_BIT ( TEST_SET_BIT           ),
+        .AWH    ( 32                     ),
+        .DWH    ( 288                    ),
+        .OWH    ( 1                      ),
+        .AWM    ( ADDR_MEM_WIDTH+2       )
+      ) i_hci_interconnect (
+        .clk_i  ( clk_i                ),
+        .rst_ni ( rst_ni               ),
+        .clear_i( 1'b0                 ),
+        .ctrl_i ( hci_ctrl_i           ),
+        .cores  ( core_hwpe_tcdm_slave ),
+        .hwpe   ( null_hwpe_tcdm_slave ),
+        .dma    ( dma_slave            ),
+        .ext    ( ext_slave            ),
+        .mems   ( tcdm_sram_master     )
+      );
+
+    end
+  endgenerate
 
   //********************************************************
   //******* LOGARITHMIC INTERCONNECT TO PERIPHERALS ********

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -93,7 +93,7 @@ module cluster_peripherals
   XBAR_PERIPH_BUS.Master              hwpe_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
-  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
+  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o
 
   //output logic [NB_L1_CUTS-1:0][RW_MARGIN_WIDTH-1:0] rw_margin_L1_o,
 

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -92,8 +92,8 @@ module cluster_peripherals
 
   XBAR_PERIPH_BUS.Master              hwpe_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
-  output logic                        hwpe_sel_o,
-  output logic                        hwpe_en_o
+  output logic                        hwpe_en_o,
+  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
 
   //output logic [NB_L1_CUTS-1:0][RW_MARGIN_WIDTH-1:0] rw_margin_L1_o,
 
@@ -193,8 +193,8 @@ module cluster_peripherals
         .boot_addr_o    ( boot_addr_o                  ),
 
         // SRAM SPEED REGULATION --> TCDM
-        .hwpe_sel_o     ( hwpe_sel_o                   ),
         .hwpe_en_o      ( hwpe_en_o                    ),
+        .hci_ctrl_o     ( hci_ctrl_o                   ),
 
         .fregfile_disable_o ( fregfile_disable_o       ),
 

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -333,8 +333,7 @@ module cluster_peripherals
      #(
        .NB_CACHE_BANKS ( NB_CACHE_BANKS       ),
        .NB_CORES       ( NB_CORES             ),
-       .ID_WIDTH       ( NB_CORES+NB_MPERIPHS ),
-       .FEATURE_STAT   ( FEATURE_STAT         )
+       .ID_WIDTH       ( NB_CORES+NB_MPERIPHS )
        )
    icache_ctrl_unit_i
      (

--- a/rtl/core_region.sv
+++ b/rtl/core_region.sv
@@ -96,11 +96,10 @@ module core_region
   //input logic             debug_core_resume_i,
               
   // Interface for DEMUX to TCDM INTERCONNECT ,PERIPHERAL INTERCONNECT and DMA CONTROLLER
-  XBAR_TCDM_BUS.Master                   tcdm_data_master,
+  hci_core_intf.master tcdm_data_master,
   //XBAR_TCDM_BUS.Master dma_ctrl_master,
-  XBAR_PERIPH_BUS.Master                 eu_ctrl_master,
-  XBAR_PERIPH_BUS.Master                 periph_data_master
-
+  XBAR_PERIPH_BUS.Master eu_ctrl_master,
+  XBAR_PERIPH_BUS.Master periph_data_master
 
  // new interface signals
  `ifdef SHARED_FPU_CLUSTER
@@ -418,11 +417,11 @@ module core_region
     .data_req_o_SH      (  tcdm_data_master.req       ),
     .data_add_o_SH      (  tcdm_data_master.add       ),
     .data_wen_o_SH      (  tcdm_data_master.wen       ),
-    .data_wdata_o_SH    (  tcdm_data_master.wdata     ),
+    .data_wdata_o_SH    (  tcdm_data_master.data      ),
     .data_be_o_SH       (  tcdm_data_master.be        ),
     .data_gnt_i_SH      (  tcdm_data_master.gnt       ),
     .data_r_valid_i_SH  (  tcdm_data_master.r_valid   ),
-    .data_r_rdata_i_SH  (  tcdm_data_master.r_rdata   ),
+    .data_r_rdata_i_SH  (  tcdm_data_master.r_data    ),
 
     .data_req_o_EXT     (  eu_ctrl_master.req         ),
     .data_add_o_EXT     (  eu_ctrl_master.add         ),
@@ -460,6 +459,9 @@ module core_region
     .perf_l2_st_cyc_o   (  perf_counters[3]           ),
     .CLUSTER_ID         (  cluster_id_i               )
   );
+
+  assign tcdm_data_master.boffs = '0;
+  assign tcdm_data_master.lrdy  = '1;
 
   // periph_demux periph_demux_i (
   //   .clk               ( clk_int                  ),

--- a/rtl/dmac_wrap.sv
+++ b/rtl/dmac_wrap.sv
@@ -115,13 +115,15 @@ module dmac_wrap
     for (genvar i=0; i<4; i++) begin : TCDM_MASTER_BIND
       assign tcdm_master[i].add      = s_tcdm_bus_add[i];
       assign tcdm_master[i].req      = s_tcdm_bus_req[i];
-      assign tcdm_master[i].wdata    = s_tcdm_bus_wdata[i];
+      assign tcdm_master[i].data     = s_tcdm_bus_wdata[i];
       assign tcdm_master[i].wen      = s_tcdm_bus_wen[i];
       assign tcdm_master[i].be       = s_tcdm_bus_be[i];
+      assign tcdm_master[i].boffs    = '0;
+      assign tcdm_master[i].lrdy     = '1;
 
       assign s_tcdm_bus_gnt[i]       = tcdm_master[i].gnt;
       assign s_tcdm_bus_r_valid[i]   = tcdm_master[i].r_valid;
-      assign s_tcdm_bus_r_rdata[i]   = tcdm_master[i].r_rdata;
+      assign s_tcdm_bus_r_rdata[i]   = tcdm_master[i].r_data;
     end
   endgenerate
    

--- a/rtl/dmac_wrap.sv
+++ b/rtl/dmac_wrap.sv
@@ -39,7 +39,7 @@ module dmac_wrap
   XBAR_PERIPH_BUS.Slave            cl_ctrl_slave,
   XBAR_PERIPH_BUS.Slave            fc_ctrl_slave,
   
-  XBAR_TCDM_BUS.Master             tcdm_master[3:0],
+  hci_core_intf.master             tcdm_master[3:0],
   AXI_BUS.Master                   ext_master,
   output logic                     term_event_cl_o,
   output logic                     term_irq_cl_o,

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -13,6 +13,8 @@
  * Francesco Conti <fconti@iis.ee.ethz.ch>
  */
 
+import hci_package::*;
+
 module hwpe_subsystem
 #(
   parameter N_CORES       = 8,
@@ -24,65 +26,47 @@ module hwpe_subsystem
   input  logic                    rst_n,
   input  logic                    test_mode,
   
-  XBAR_TCDM_BUS.Master            hwpe_xbar_master[N_MASTER_PORT-1:0],
+  hci_core_intf.master            hwpe_xbar_master,
   XBAR_PERIPH_BUS.Slave           hwpe_cfg_slave,
+  output hci_interconnect_ctrl_t  hci_ctrl_o,
 
   output logic [N_CORES-1:0][1:0] evt_o,
   output logic                    busy_o
 );
 
-  logic [4-1:0]          tcdm_req;
-  logic [4-1:0]          tcdm_gnt;
-  logic [4-1:0] [32-1:0] tcdm_add;
-  logic [4-1:0]          tcdm_type;
-  logic [4-1:0] [4 -1:0] tcdm_be;
-  logic [4-1:0] [32-1:0] tcdm_wdata;
-  logic [4-1:0] [32-1:0] tcdm_r_rdata;
-  logic [4-1:0]          tcdm_r_valid;
+  hwpe_ctrl_intf_periph #(
+    .ID_WIDTH ( ID_WIDTH )
+  ) periph (
+    .clk ( clk )
+  );
 
-  // use the mac engine as example accelerator
-  mac_top_wrap #(
+  rbe_top #(
+    .ID      ( ID_WIDTH ),
     .N_CORES ( N_CORES  ),
-    .ID      ( ID_WIDTH )
-  ) mac_top_wrap_i (
-    .clk_i            ( clk                    ),
-    .rst_ni           ( rst_n                  ),
-    .test_mode_i      ( test_mode              ),
-    .tcdm_req         ( tcdm_req               ),
-    .tcdm_gnt         ( tcdm_gnt               ),
-    .tcdm_add         ( tcdm_add               ),
-    .tcdm_wen         ( tcdm_type              ),
-    .tcdm_be          ( tcdm_be                ),
-    .tcdm_data        ( tcdm_wdata             ),
-    .tcdm_r_data      ( tcdm_r_rdata           ),
-    .tcdm_r_valid     ( tcdm_r_valid           ),
-    .periph_req       ( hwpe_cfg_slave.req     ),
-    .periph_gnt       ( hwpe_cfg_slave.gnt     ),
-    .periph_add       ( hwpe_cfg_slave.add     ),
-    .periph_wen       ( ~hwpe_cfg_slave.wen    ),
-    .periph_be        ( hwpe_cfg_slave.be      ),
-    .periph_data      ( hwpe_cfg_slave.wdata   ),
-    .periph_id        ( hwpe_cfg_slave.id      ),
-    .periph_r_data    ( hwpe_cfg_slave.r_rdata ),
-    .periph_r_valid   ( hwpe_cfg_slave.r_valid ),
-    .periph_r_id      ( hwpe_cfg_slave.r_id    ),
-    .evt_o            ( evt_o                  )
+    .BW      ( 288      )
+  ) hwpe_top_wrap_i (
+    .clk_i       ( clk              ),
+    .rst_ni      ( rst_n            ),
+    .test_mode_i ( test_mode        ),
+    .evt_o       ( evt_o            ),
+    .tcdm        ( hwpe_xbar_master ),
+    .hci_ctrl_o  ( hci_ctrl_o       ),
+    .periph      ( periph           )
   );
   assign busy_o = 1'b1;
 
-  genvar i;
-  generate
-    for (i=0;i<4;i++) begin : hwpe_binding
-      assign hwpe_xbar_master[i].req   = tcdm_req   [i];
-      assign hwpe_xbar_master[i].add   = tcdm_add   [i];
-      assign hwpe_xbar_master[i].wen   = tcdm_type  [i];
-      assign hwpe_xbar_master[i].wdata = tcdm_wdata [i];
-      assign hwpe_xbar_master[i].be    = tcdm_be    [i];
-      // response channel
-      assign tcdm_gnt     [i] = hwpe_xbar_master[i].gnt;
-      assign tcdm_r_rdata [i] = hwpe_xbar_master[i].r_rdata;
-      assign tcdm_r_valid [i] = hwpe_xbar_master[i].r_valid;
-    end
-  endgenerate
+  always_comb
+  begin
+    periph.req  = hwpe_cfg_slave.req;
+    periph.add  = hwpe_cfg_slave.add;
+    periph.wen  = hwpe_cfg_slave.wen;
+    periph.be   = hwpe_cfg_slave.be;
+    periph.data = hwpe_cfg_slave.wdata;
+    periph.id   = hwpe_cfg_slave.id;
+  end
+  assign hwpe_cfg_slave.gnt     = periph.gnt;
+  assign hwpe_cfg_slave.r_rdata = periph.r_data;
+  assign hwpe_cfg_slave.r_valid = periph.r_valid;
+  assign hwpe_cfg_slave.r_id    = periph.r_id;
 
 endmodule

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -43,6 +43,7 @@ module pulp_cluster
   parameter TCDM_BANK_SIZE          = TCDM_SIZE/NB_TCDM_BANKS, // [B]
   parameter TCDM_NUM_ROWS           = TCDM_BANK_SIZE/4,        // [words]
   parameter HWPE_PRESENT            = 1,                       // set to 1 if HW Processing Engines are present in the cluster
+  parameter USE_HETEROGENEOUS_INTERCONNECT = 1,                // set to 1 to connect HWPEs via heterogeneous interconnect; to 0 for larger LIC
 
   // I$ parameters
   parameter SET_ASSOCIATIVE         = 4,
@@ -710,7 +711,8 @@ module pulp_cluster
     .ADDR_MEM_WIDTH     ( ADDR_MEM_WIDTH     ),
 
     .LOG_CLUSTER        ( LOG_CLUSTER        ),
-    .PE_ROUTING_LSB     ( PE_ROUTING_LSB     )
+    .PE_ROUTING_LSB     ( PE_ROUTING_LSB     ),
+    .USE_HETEROGENEOUS_INTERCONNECT ( USE_HETEROGENEOUS_INTERCONNECT )
 
   ) cluster_interconnect_wrap_i (
     .clk_i              ( clk_cluster                         ),
@@ -836,7 +838,7 @@ module pulp_cluster
     .hwpe_cfg_master        ( s_hwpe_cfg_bus                     ),
     .hwpe_events_i          ( s_hwpe_remap_evt                   ),
     .hwpe_en_o              ( s_hwpe_en                          ),
-    .hci_ctrl_o             ( s_hci_ctrl                         ),
+    .hci_ctrl_o             ( s_hci_ctrl                         )
 `ifdef PRIVATE_ICACHE
     ,
     .IC_ctrl_unit_bus_main  (  IC_ctrl_unit_bus_main              ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1224,7 +1224,6 @@ module pulp_cluster
     .NB_WAYS          ( SET_ASSOCIATIVE    ),
     .CACHE_SIZE       ( CACHE_SIZE         ),
     .CACHE_LINE       ( 1                  ),
-    .FEATURE_STAT     ( FEATURE_STAT       ),
     .AXI_ID           ( AXI_ID_OUT_WIDTH   ),
     .AXI_ADDR         ( AXI_ADDR_WIDTH     ),
     .AXI_USER         ( AXI_USER_WIDTH     ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -18,6 +18,7 @@
  */
 
 import pulp_cluster_package::*;
+import hci_package::*;
 
 `include "pulp_soc_defines.sv"
 `include "cluster_bus_defines.sv"
@@ -27,11 +28,13 @@ module pulp_cluster
 #(
   // cluster parameters
   parameter CORE_TYPE_CL            = 0, // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
-  parameter NB_CORES                = 8,
-  parameter NB_HWPE_PORTS           = 4,
-  parameter NB_DMAS                 = 4,
-  parameter NB_MPERIPHS             = NB_MPERIPHS,
-  parameter NB_SPERIPHS             = NB_SPERIPHS,
+  parameter NB_CORES           = 8,
+  parameter NB_HWPE_PORTS      = 9,
+  // number of DMA TCDM plugs, NOT number of DMA slave peripherals!
+  // Everything will go to hell if you change this!
+  parameter NB_DMAS            = 4,
+  parameter NB_MPERIPHS        = NB_MPERIPHS,
+  parameter NB_SPERIPHS        = NB_SPERIPHS,
   
   parameter CLUSTER_ALIAS_BASE      = 12'h000,
   
@@ -147,7 +150,7 @@ module pulp_cluster
   output logic                             pf_evt_valid_o,
 
   input logic  [NB_CORES-1:0]              dbg_irq_valid_i,
-   
+
   // AXI4 SLAVE
   //***************************************
   // WRITE ADDRESS CHANNEL
@@ -301,6 +304,7 @@ module pulp_cluster
   logic [NB_CORES-1:0][3:0] s_hwpe_remap_evt;
   logic [NB_CORES-1:0][1:0] s_hwpe_evt;
   logic                     s_hwpe_busy;
+  hci_package::hci_interconnect_ctrl_t s_hci_ctrl;
 
   logic [NB_CORES-1:0]               clk_core_en;
   logic                              clk_cluster;
@@ -360,8 +364,14 @@ module pulp_cluster
 
 
   /* logarithmic and peripheral interconnect interfaces */
-  // ext -> log interconnect 
-  XBAR_TCDM_BUS s_ext_xbar_bus[NB_DMAS-1:0]();
+  // ext -> log interconnect
+  hci_core_intf #(
+    .DW ( 32 ),
+    .AW ( 32 ),
+    .OW ( 1  )
+  ) s_hci_ext[NB_DMAS-1:0] (
+    .clk ( clk_cluster )
+  );
 
   // periph interconnect -> slave peripherals
   XBAR_PERIPH_BUS s_xbar_speriph_bus[NB_SPERIPHS-1:0]();
@@ -370,7 +380,13 @@ module pulp_cluster
   XBAR_PERIPH_BUS s_hwpe_cfg_bus();
 
   // DMA -> log interconnect
-  XBAR_TCDM_BUS s_dma_xbar_bus[NB_DMAS-1:0]();
+  hci_core_intf #(
+    .DW ( 32 ),
+    .AW ( 32 ),
+    .OW ( 1  )
+  ) s_hci_dma[NB_DMAS-1:0] (
+    .clk ( clk_cluster )
+  );
   XBAR_TCDM_BUS    s_dma_plugin_xbar_bus[NB_DMAS-1:0]();
 
   // ext -> xbar periphs FIXME
@@ -381,8 +397,21 @@ module pulp_cluster
   XBAR_TCDM_BUS s_mperiph_demux_bus[1:0]();
   
   // cores & accelerators -> log interconnect
-  XBAR_TCDM_BUS s_core_xbar_bus[NB_CORES+NB_HWPE_PORTS-1:0]();
-  
+  hci_core_intf #(
+    .DW ( NB_HWPE_PORTS*32 ),
+    .AW ( 32               ),
+    .OW ( 1                )
+  ) s_hci_hwpe [0:0] (
+    .clk ( clk_cluster )
+  );
+  hci_core_intf #(
+    .DW ( 32 ),
+    .AW ( 32 ),
+    .OW ( 1  )
+  ) s_hci_core [NB_CORES-1:0] (
+    .clk ( clk_cluster )
+  );
+
   // cores -> periph interconnect
   XBAR_PERIPH_BUS s_core_periph_bus[NB_CORES-1:0]();
   
@@ -437,10 +466,15 @@ module pulp_cluster
       `endif
   `endif
    //----------------------------------------------------------------------//
-   
-  // log interconnect -> TCDM memory banks (SRAM)
-  TCDM_BANK_MEM_BUS s_tcdm_bus_sram[NB_TCDM_BANKS-1:0]();
 
+  localparam TCDM_ID_WIDTH = NB_CORES+NB_DMAS+4+NB_HWPE_PORTS;
+
+  // log interconnect -> TCDM memory banks (SRAM)
+  hci_mem_intf #(
+    .IW ( TCDM_ID_WIDTH )
+  ) s_tcdm_bus_sram[NB_TCDM_BANKS-1:0](
+    .clk ( clk_cluster )
+  );
 
   //***************************************************
   /* asynchronous AXI interfaces at CLUSTER/SOC interface */
@@ -587,7 +621,7 @@ module pulp_cluster
     .rst_ni      ( rst_ni         ),
     .test_en_i   ( test_mode_i    ),
     .axi_slave   ( s_ext_tcdm_bus ),
-    .tcdm_master ( s_ext_xbar_bus ),
+    .tcdm_master ( s_hci_ext      ),
     .busy_o      ( s_axi2mem_busy )
   );
 
@@ -683,18 +717,18 @@ module pulp_cluster
     .clk_i              ( clk_cluster                         ),
     .rst_ni             ( rst_ni                              ),
 
-    .core_tcdm_slave    ( s_core_xbar_bus                     ),
-    .core_periph_slave  ( s_core_periph_bus                   ),
-
-    .ext_slave          ( s_ext_xbar_bus                      ),
-
-    .dma_slave          ( s_dma_xbar_bus                      ),
-    .mperiph_slave      ( s_mperiph_xbar_bus[NB_MPERIPHS-1:0] ),
+    .core_tcdm_slave    ( s_hci_core                          ),
+    .hwpe_tcdm_slave    ( s_hci_hwpe                          ),
+    .ext_slave          ( s_hci_ext                           ),
+    .dma_slave          ( s_hci_dma                           ),
 
     .tcdm_sram_master   ( s_tcdm_bus_sram                     ),
 
+    .core_periph_slave  ( s_core_periph_bus                   ),
+    .mperiph_slave      ( s_mperiph_xbar_bus[NB_MPERIPHS-1:0] ),
     .speriph_master     ( s_xbar_speriph_bus                  ),
 
+    .hci_ctrl_i         ( s_hci_ctrl                          ),
     .TCDM_arb_policy_i  ( s_TCDM_arb_policy                   )
   );
 
@@ -723,7 +757,7 @@ module pulp_cluster
     //.ctrl_slave     ( s_core_dmactrl_bus ), // eliminate
     .cl_ctrl_slave  ( s_periph_dma_bus[0]),
     .fc_ctrl_slave  ( s_periph_dma_bus[1]),
-    .tcdm_master    ( s_dma_xbar_bus     ),
+    .tcdm_master    ( s_hci_dma          ),
     .ext_master     ( s_dma_ext_bus      ),
     .term_event_cl_o( s_dma_cl_event     ),
     .term_irq_cl_o  ( s_dma_cl_irq       ),
@@ -903,7 +937,7 @@ module pulp_cluster
         //.debug_core_halted_o ( dbg_core_halted[i]    ),
         //.debug_core_halt_i   ( dbg_core_halt[i]      ),
         //.debug_core_resume_i ( dbg_core_resume[i]    ),
-        .tcdm_data_master    ( s_core_xbar_bus[i]    ),
+        .tcdm_data_master    ( s_hci_core[i]         ),
 
         //tcdm, dma ctrl unit, periph interco interfaces
         //.dma_ctrl_master     ( s_core_dmactrl_bus[i] ),
@@ -1045,13 +1079,14 @@ module pulp_cluster
         .N_MASTER_PORT ( 4                    ),
         .ID_WIDTH      ( NB_CORES+NB_MPERIPHS )
       ) hwpe_subsystem_i (
-        .clk               ( clk_cluster                                        ),
-        .rst_n             ( s_rst_n                                            ),
-        .test_mode         ( test_mode_i                                        ),
-        .hwpe_xbar_master  ( s_core_xbar_bus[NB_CORES+NB_HWPE_PORTS-1:NB_CORES] ),
-        .hwpe_cfg_slave    ( s_hwpe_cfg_bus                                     ),
-        .evt_o             ( s_hwpe_evt                                         ),
-        .busy_o            ( s_hwpe_busy                                        )
+        .clk               ( clk_cluster    ),
+        .rst_n             ( s_rst_n        ),
+        .test_mode         ( test_mode_i    ),
+        .hwpe_xbar_master  ( s_hci_hwpe [0] ),
+        .hwpe_cfg_slave    ( s_hwpe_cfg_bus ),
+        .hci_ctrl_o        ( s_hci_ctrl     ),
+        .evt_o             ( s_hwpe_evt     ),
+        .busy_o            ( s_hwpe_busy    )
       );
     end
     else begin : no_hwpe_gen
@@ -1059,12 +1094,13 @@ module pulp_cluster
       assign s_hwpe_cfg_bus.gnt     = '1;
       assign s_hwpe_cfg_bus.r_rdata = 32'hdeadbeef;
       assign s_hwpe_cfg_bus.r_id    = '0;
-      for (genvar i=NB_CORES; i<NB_CORES+NB_HWPE_PORTS; i++) begin : no_hwpe_bias
-        assign s_core_xbar_bus[i].req = '0;
-        assign s_core_xbar_bus[i].wen = '0;
-        assign s_core_xbar_bus[i].be  = '0;
-        assign s_core_xbar_bus[i].wdata = '0;
-      end
+      assign s_hci_hwpe[0].req   = 1'b0;
+      assign s_hci_hwpe[0].add   = '0;
+      assign s_hci_hwpe[0].wen   = '0;
+      assign s_hci_hwpe[0].data  = '0;
+      assign s_hci_hwpe[0].be    = '0;
+      assign s_hci_hwpe[0].boffs = '0;
+      assign s_hci_hwpe[0].lrdy  = '1;
       assign s_hwpe_busy = '0;
       assign s_hwpe_evt  = '0;
        

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -290,7 +290,6 @@ module pulp_cluster
   logic [NB_CORES-1:0]                dbg_core_resume;
   logic [NB_CORES-1:0]                dbg_core_halted;
   logic [NB_CORES-1:0]                s_dbg_irq;
-  logic                               s_hwpe_sel;
   logic                               s_hwpe_en;
 
   logic                     s_cluster_periphs_busy;
@@ -836,8 +835,8 @@ module pulp_cluster
     
     .hwpe_cfg_master        ( s_hwpe_cfg_bus                     ),
     .hwpe_events_i          ( s_hwpe_remap_evt                   ),
-    .hwpe_sel_o             ( s_hwpe_sel                         ),
-    .hwpe_en_o              ( s_hwpe_en                          )
+    .hwpe_en_o              ( s_hwpe_en                          ),
+    .hci_ctrl_o             ( s_hci_ctrl                         ),
 `ifdef PRIVATE_ICACHE
     ,
     .IC_ctrl_unit_bus_main  (  IC_ctrl_unit_bus_main              ),
@@ -1076,7 +1075,7 @@ module pulp_cluster
     if(HWPE_PRESENT == 1) begin : hwpe_gen
       hwpe_subsystem #(
         .N_CORES       ( NB_CORES             ),
-        .N_MASTER_PORT ( 4                    ),
+        .N_MASTER_PORT ( NB_HWPE_PORTS        ),
         .ID_WIDTH      ( NB_CORES+NB_MPERIPHS )
       ) hwpe_subsystem_i (
         .clk               ( clk_cluster    ),
@@ -1084,7 +1083,6 @@ module pulp_cluster
         .test_mode         ( test_mode_i    ),
         .hwpe_xbar_master  ( s_hci_hwpe [0] ),
         .hwpe_cfg_slave    ( s_hwpe_cfg_bus ),
-        .hci_ctrl_o        ( s_hci_ctrl     ),
         .evt_o             ( s_hwpe_evt     ),
         .busy_o            ( s_hwpe_busy    )
       );
@@ -1103,7 +1101,6 @@ module pulp_cluster
       assign s_hci_hwpe[0].lrdy  = '1;
       assign s_hwpe_busy = '0;
       assign s_hwpe_evt  = '0;
-       
     end
   endgenerate
   

--- a/rtl/tcdm_banks_wrap.sv
+++ b/rtl/tcdm_banks_wrap.sv
@@ -44,10 +44,9 @@ module tcdm_banks_wrap
     input  logic               init_ni,
     input  logic               pwdn_i,
     input  logic               test_mode_i,
-
-    TCDM_BANK_MEM_BUS.Slave    tcdm_slave[NB_BANKS-1:0]
-    );
-
+    hci_mem_intf.slave    tcdm_slave[NB_BANKS-1:0]
+   );
+   
    generate
       for(genvar i=0; i<NB_BANKS; i++) begin : banks_gen
 
@@ -59,13 +58,15 @@ module tcdm_banks_wrap
 	 logic [32-1:0]                bank_d;
 	 logic [32-1:0]                bank_q;
 
-	 assign bank_a              = tcdm_slave[i].add[$clog2(BANK_SIZE)-1:0];
-	 assign bank_d              = tcdm_slave[i].wdata;
+	 assign bank_a              =  tcdm_slave[i].add[$clog2(BANK_SIZE)+2-1:2];
+	 assign bank_d              =  tcdm_slave[i].data;
 	 assign bank_be_n           = ~tcdm_slave[i].be;
 	 assign bank_ce_n           = ~tcdm_slave[i].req;
-	 assign bank_rdwe_n         = tcdm_slave[i].wen;
-	 assign tcdm_slave[i].rdata = bank_q;
-
+	 assign bank_rdwe_n         =  tcdm_slave[i].wen;
+	 assign tcdm_slave[i].r_data = bank_q;
+         assign tcdm_slave[i].gnt    = 1'b1;
+         assign tcdm_slave[i].r_id   = '0;
+	 
 	 generic_memory
 	   #(
 	     .ADDR_WIDTH($clog2(BANK_SIZE))

--- a/rtl/tcdm_banks_wrap.sv
+++ b/rtl/tcdm_banks_wrap.sv
@@ -1,9 +1,6 @@
 // Copyright 2018 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
-// Copyright 2018 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at
 // http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
 // or agreed to in writing, software, hardware and materials distributed under
@@ -44,6 +41,7 @@ module tcdm_banks_wrap
     input  logic               init_ni,
     input  logic               pwdn_i,
     input  logic               test_mode_i,
+    
     hci_mem_intf.slave    tcdm_slave[NB_BANKS-1:0]
    );
    

--- a/src_files.yml
+++ b/src_files.yml
@@ -1,6 +1,7 @@
 pulp_cluster:
   vlog_opts: [
     -L fpnew_lib,
+    -L hci_lib,
   ]
   incdirs: [
     ../../rtl/includes,


### PR DESCRIPTION
This PR integrates the Heterogeneous Cluster Interconnect in the PULP cluster, together with a demo "datamover" accelerator.
Still pending before merge:
- regression test with and without HCI
- align FPU interco version and cluster_peripherals version -- right now they are outdated, and in the case of cluster_peripherals, some changes to the new version are required.