### PR TITLE
Added access to dma_wrap by every core_region through periph demux. 

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -53,6 +53,7 @@ sources:
   - rtl/per_demux_wrap.sv
   - rtl/periph_FIFO.sv
   - rtl/tcdm_banks_wrap.sv
+  - rtl/periph_demux.sv
     # Level 1
   - rtl/cluster_peripherals.sv
   - rtl/core_demux.sv

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -51,19 +51,19 @@ module cluster_peripherals
   output logic                        cluster_cg_en_o,
 
   output logic                        busy_o,
-
+                                    
   XBAR_PERIPH_BUS.Slave               speriph_slave[NB_SPERIPHS-2:0],
   XBAR_PERIPH_BUS.Slave               core_eu_direct_link[NB_CORES-1:0],
 
-  //input  logic [NB_CORES-1:0]         dma_events_i,
-  //input  logic [NB_CORES-1:0]         dma_irq_i,
+  input  logic [NB_CORES-1:0]         dma_event_i,
+  input  logic [NB_CORES-1:0]         dma_irq_i,
 
   XBAR_PERIPH_BUS.Master              dma_cfg_master[1:0],
   input logic                         dma_cl_event_i,
   input logic                         dma_cl_irq_i,
   //input  logic                        dma_pe_irq_i,
   //output logic                        pf_event_o,
-
+ 
   input logic                         dma_fc_event_i,
   input logic                         dma_fc_irq_i,
   
@@ -89,12 +89,12 @@ module cluster_peripherals
 
   // SRAM SPEED REGULATION --> TCDM
   output logic [1:0]                  TCDM_arb_policy_o,
-
+                                    
   XBAR_PERIPH_BUS.Master              hwpe_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
-  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o
-
+  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o   
+                                
   //output logic [NB_L1_CUTS-1:0][RW_MARGIN_WIDTH-1:0] rw_margin_L1_o,
 
   // Control ports
@@ -117,7 +117,8 @@ module cluster_peripherals
   `endif
 `endif
  
-);
+ 
+  );
    
   logic                      s_timer_out_lo_event;
   logic                      s_timer_out_hi_event;
@@ -158,8 +159,8 @@ module cluster_peripherals
       assign s_cluster_events[I] = 32'd0;
       assign s_acc_events[I]     = hwpe_events_i[I];
       assign s_timer_events[I]   = {s_timer_out_hi_event,s_timer_out_lo_event};
-      assign s_dma_events[I][0] = dma_cl_event_i;
-      assign s_dma_events[I][1] = dma_cl_irq_i;
+      assign s_dma_events[I][0] = dma_event_i[I];
+      assign s_dma_events[I][1] = dma_irq_i[I];
     end
   endgenerate
   

--- a/rtl/core_region.sv
+++ b/rtl/core_region.sv
@@ -97,7 +97,7 @@ module core_region
               
   // Interface for DEMUX to TCDM INTERCONNECT ,PERIPHERAL INTERCONNECT and DMA CONTROLLER
   hci_core_intf.master tcdm_data_master,
-  //XBAR_TCDM_BUS.Master dma_ctrl_master,
+  XBAR_TCDM_BUS.Master dma_ctrl_master,
   XBAR_PERIPH_BUS.Master eu_ctrl_master,
   XBAR_PERIPH_BUS.Master periph_data_master
 
@@ -144,6 +144,7 @@ module core_region
   //********************************************************
 
   XBAR_DEMUX_BUS    s_core_bus();         // Internal interface between CORE       <--> DEMUX
+  XBAR_PERIPH_BUS   periph_demux_bus();   // Internal interface between CORE_DEMUX <--> PERIPHERAL DEMUX
 
   logic [4:0]      perf_counters;
   logic            clk_int;
@@ -421,15 +422,15 @@ module core_region
     .data_r_valid_i_SH  (  tcdm_data_master.r_valid   ),
     .data_r_rdata_i_SH  (  tcdm_data_master.r_data    ),
 
-    .data_req_o_EXT     (  eu_ctrl_master.req         ),
-    .data_add_o_EXT     (  eu_ctrl_master.add         ),
-    .data_wen_o_EXT     (  eu_ctrl_master.wen         ),
-    .data_wdata_o_EXT   (  eu_ctrl_master.wdata       ),
-    .data_be_o_EXT      (  eu_ctrl_master.be          ),
-    .data_gnt_i_EXT     (  eu_ctrl_master.gnt         ),
-    .data_r_valid_i_EXT (  eu_ctrl_master.r_valid     ),
-    .data_r_rdata_i_EXT (  eu_ctrl_master.r_rdata     ),
-    .data_r_opc_i_EXT   (  eu_ctrl_master.r_opc       ),
+    .data_req_o_EXT     (  periph_demux_bus.req         ),
+    .data_add_o_EXT     (  periph_demux_bus.add         ),
+    .data_wen_o_EXT     (  periph_demux_bus.wen         ),
+    .data_wdata_o_EXT   (  periph_demux_bus.wdata       ),
+    .data_be_o_EXT      (  periph_demux_bus.be          ),
+    .data_gnt_i_EXT     (  periph_demux_bus.gnt         ),
+    .data_r_valid_i_EXT (  periph_demux_bus.r_valid     ),
+    .data_r_rdata_i_EXT (  periph_demux_bus.r_rdata     ),
+    .data_r_opc_i_EXT   (  periph_demux_bus.r_opc       ),
 
     .data_req_o_PE      (  periph_data_master.req     ),
     .data_add_o_PE      (  periph_data_master.add     ),
@@ -450,6 +451,44 @@ module core_region
 
   assign tcdm_data_master.boffs = '0;
   assign tcdm_data_master.lrdy  = '1;
+
+   periph_demux periph_demux_i (
+     .clk               ( clk_int                  ),
+     .rst_ni            ( rst_ni                   ),
+
+     .data_req_i        ( periph_demux_bus.req     ),
+     .data_add_i        ( periph_demux_bus.add     ),
+     .data_wen_i        ( periph_demux_bus.wen     ),
+     .data_wdata_i      ( periph_demux_bus.wdata   ),
+     .data_be_i         ( periph_demux_bus.be      ),
+     .data_gnt_o        ( periph_demux_bus.gnt     ),
+
+     .data_r_valid_o    ( periph_demux_bus.r_valid ),
+     .data_r_opc_o      ( periph_demux_bus.r_opc   ),
+     .data_r_rdata_o    ( periph_demux_bus.r_rdata ),
+
+     .data_req_o_MH     ( dma_ctrl_master.req      ),
+     .data_add_o_MH     ( dma_ctrl_master.add      ),
+     .data_wen_o_MH     ( dma_ctrl_master.wen      ),
+     .data_wdata_o_MH   ( dma_ctrl_master.wdata    ),
+     .data_be_o_MH      ( dma_ctrl_master.be       ),
+     .data_gnt_i_MH     ( dma_ctrl_master.gnt      ),
+
+     .data_r_valid_i_MH ( dma_ctrl_master.r_valid  ),
+     .data_r_rdata_i_MH ( dma_ctrl_master.r_rdata  ),
+     .data_r_opc_i_MH   ( dma_ctrl_master.r_opc    ),
+
+     .data_req_o_EU     ( eu_ctrl_master.req       ),
+     .data_add_o_EU     ( eu_ctrl_master.add       ),
+     .data_wen_o_EU     ( eu_ctrl_master.wen       ),
+     .data_wdata_o_EU   ( eu_ctrl_master.wdata     ),
+     .data_be_o_EU      ( eu_ctrl_master.be        ),
+     .data_gnt_i_EU     ( eu_ctrl_master.gnt       ),
+
+     .data_r_valid_i_EU ( eu_ctrl_master.r_valid   ),
+     .data_r_rdata_i_EU ( eu_ctrl_master.r_rdata   ),
+     .data_r_opc_i_EU   ( eu_ctrl_master.r_opc     )
+    );
 
   /* debug stuff */
   //synopsys translate_off

--- a/rtl/dmac_wrap.sv
+++ b/rtl/dmac_wrap.sv
@@ -33,46 +33,37 @@ module dmac_wrap
   parameter BE_WIDTH           = DATA_WIDTH/8
 )
 ( 
-  input logic                      clk_i,
-  input logic                      rst_ni,
-  input logic                      test_mode_i,
-  XBAR_PERIPH_BUS.Slave            cl_ctrl_slave,
-  XBAR_PERIPH_BUS.Slave            fc_ctrl_slave,
-  
-  hci_core_intf.master             tcdm_master[3:0],
-  AXI_BUS.Master                   ext_master,
-  output logic                     term_event_cl_o,
-  output logic                     term_irq_cl_o,
-  output logic                     term_event_pe_o,
-  output logic                     term_irq_pe_o,
-  output logic                     busy_o
+  input logic  clk_i,
+  input logic  rst_ni,
+  input logic  test_mode_i,
+
+  XBAR_TCDM_BUS.Slave   ctrl_slave[NB_CORES-1:0],
+  XBAR_PERIPH_BUS.Slave cl_ctrl_slave,
+  XBAR_PERIPH_BUS.Slave fc_ctrl_slave,
+   
+  hci_core_intf.master tcdm_master[3:0],
+  AXI_BUS.Master ext_master,
+  output logic term_event_cl_o,
+  output logic term_irq_cl_o,
+  output logic term_event_pe_o,
+  output logic term_irq_pe_o,
+  output logic [NB_CORES-1:0] term_event_o,
+  output logic [NB_CORES-1:0] term_irq_o,
+  output logic busy_o
 );
   
   //   CORE --> MCHAN CTRL INTERFACE BUS SIGNALS
-     logic [NB_CTRLS-1:0][DATA_WIDTH-1:0]  s_ctrl_bus_wdata;
-     logic [NB_CTRLS-1:0][ADDR_WIDTH-1:0]  s_ctrl_bus_add;
-     logic [NB_CTRLS-1:0]                  s_ctrl_bus_req;
-     logic [NB_CTRLS-1:0]                  s_ctrl_bus_wen;
-     logic [NB_CTRLS-1:0][BE_WIDTH-1:0]    s_ctrl_bus_be;
-     logic [NB_CTRLS-1:0][PE_ID_WIDTH-1:0] s_ctrl_bus_id;
-     logic [NB_CTRLS-1:0]                  s_ctrl_bus_gnt;
-     logic [NB_CTRLS-1:0][DATA_WIDTH-1:0]  s_ctrl_bus_r_rdata;
-     logic [NB_CTRLS-1:0]                  s_ctrl_bus_r_valid;
-     logic [NB_CTRLS-1:0]                  s_ctrl_bus_r_opc;
-     logic [NB_CTRLS-1:0][PE_ID_WIDTH-1:0] s_ctrl_bus_r_id;
-
-  // CORE --> MCHAN CTRL INTERFACE BUS SIGNALS
-/* -----\/----- EXCLUDED -----\/-----
-  logic [NB_CORES-1:0][DATA_WIDTH-1:0] s_ctrl_bus_wdata;
-  logic [NB_CORES-1:0][ADDR_WIDTH-1:0] s_ctrl_bus_add;
-  logic [NB_CORES-1:0]                 s_ctrl_bus_req;
-  logic [NB_CORES-1:0]                 s_ctrl_bus_wen;
-  logic [NB_CORES-1:0][BE_WIDTH-1:0]   s_ctrl_bus_be;
-  logic [NB_CORES-1:0]                 s_ctrl_bus_gnt;
-  logic [NB_CORES-1:0][DATA_WIDTH-1:0] s_ctrl_bus_r_rdata;
-  logic [NB_CORES-1:0]                 s_ctrl_bus_r_valid;
- -----/\----- EXCLUDED -----/\----- */
-
+  logic [NB_CTRLS-1:0][DATA_WIDTH-1:0]  s_ctrl_bus_wdata;
+  logic [NB_CTRLS-1:0][ADDR_WIDTH-1:0]  s_ctrl_bus_add;
+  logic [NB_CTRLS-1:0]                  s_ctrl_bus_req;
+  logic [NB_CTRLS-1:0]                  s_ctrl_bus_wen;
+  logic [NB_CTRLS-1:0][BE_WIDTH-1:0]    s_ctrl_bus_be;
+  logic [NB_CTRLS-1:0][PE_ID_WIDTH-1:0] s_ctrl_bus_id;
+  logic [NB_CTRLS-1:0]                  s_ctrl_bus_gnt;
+  logic [NB_CTRLS-1:0][DATA_WIDTH-1:0]  s_ctrl_bus_r_rdata;
+  logic [NB_CTRLS-1:0]                  s_ctrl_bus_r_valid;
+  logic [NB_CTRLS-1:0]                  s_ctrl_bus_r_opc;
+  logic [NB_CTRLS-1:0][PE_ID_WIDTH-1:0] s_ctrl_bus_r_id;
 
 
   // MCHAN TCDM INIT --> TCDM MEMORY BUS SIGNALS
@@ -85,31 +76,51 @@ module dmac_wrap
   logic [3:0][DATA_WIDTH-1:0] s_tcdm_bus_r_rdata;
   logic [3:0]                 s_tcdm_bus_r_valid;
 
+  // CLUSTER CORE PORT BINDING
+  generate
+    for (genvar i=0; i<NB_CORES; i++) begin
+
+     assign s_ctrl_bus_add[i]     = ctrl_slave[i].add;
+     assign s_ctrl_bus_req[i]     = ctrl_slave[i].req;
+     assign s_ctrl_bus_wdata[i]   = ctrl_slave[i].wdata;
+     assign s_ctrl_bus_wen[i]     = ctrl_slave[i].wen;
+     assign s_ctrl_bus_be[i]      = ctrl_slave[i].be;
+     assign s_ctrl_bus_id[i]      = i;
+
+       
+     assign ctrl_slave[i].gnt     = s_ctrl_bus_gnt[i];
+     assign ctrl_slave[i].r_opc   = s_ctrl_bus_r_opc[i];
+     assign ctrl_slave[i].r_valid = s_ctrl_bus_r_valid[i];
+     assign ctrl_slave[i].r_rdata = s_ctrl_bus_r_rdata[i];
+
+    end // for (genvar i=0; i<NB_CORES; i++)
+  endgenerate
+
   // // CL CTRL PORT BINDING
-  assign s_ctrl_bus_add[0]     = cl_ctrl_slave.add;
-  assign s_ctrl_bus_req[0]     = cl_ctrl_slave.req;
-  assign s_ctrl_bus_wdata[0]   = cl_ctrl_slave.wdata;
-  assign s_ctrl_bus_wen[0]     = cl_ctrl_slave.wen;
-  assign s_ctrl_bus_be[0]      = cl_ctrl_slave.be;
-  assign s_ctrl_bus_id[0]      = cl_ctrl_slave.id;
-  assign cl_ctrl_slave.gnt     = s_ctrl_bus_gnt[0];
-  assign cl_ctrl_slave.r_opc   = s_ctrl_bus_r_opc[0];
-  assign cl_ctrl_slave.r_valid = s_ctrl_bus_r_valid[0];
-  assign cl_ctrl_slave.r_rdata = s_ctrl_bus_r_rdata[0];
-  assign cl_ctrl_slave.r_id    = s_ctrl_bus_r_id[0];
+  assign s_ctrl_bus_add[NB_CORES]     = cl_ctrl_slave.add;
+  assign s_ctrl_bus_req[NB_CORES]     = cl_ctrl_slave.req;
+  assign s_ctrl_bus_wdata[NB_CORES]   = cl_ctrl_slave.wdata;
+  assign s_ctrl_bus_wen[NB_CORES]     = cl_ctrl_slave.wen;
+  assign s_ctrl_bus_be[NB_CORES]      = cl_ctrl_slave.be;
+  assign s_ctrl_bus_id[NB_CORES]      = cl_ctrl_slave.id;
+  assign cl_ctrl_slave.gnt     = s_ctrl_bus_gnt[NB_CORES];
+  assign cl_ctrl_slave.r_opc   = s_ctrl_bus_r_opc[NB_CORES];
+  assign cl_ctrl_slave.r_valid = s_ctrl_bus_r_valid[NB_CORES];
+  assign cl_ctrl_slave.r_rdata = s_ctrl_bus_r_rdata[NB_CORES];
+  assign cl_ctrl_slave.r_id    = s_ctrl_bus_r_id[NB_CORES];
 
   // FC CTRL PORT BINDING
-  assign s_ctrl_bus_add[1]     = fc_ctrl_slave.add;
-  assign s_ctrl_bus_req[1]     = fc_ctrl_slave.req;
-  assign s_ctrl_bus_wdata[1]   = fc_ctrl_slave.wdata;
-  assign s_ctrl_bus_wen[1]     = fc_ctrl_slave.wen;
-  assign s_ctrl_bus_be[1]      = fc_ctrl_slave.be;
-  assign s_ctrl_bus_id[1]      = fc_ctrl_slave.id;
-  assign fc_ctrl_slave.gnt     = s_ctrl_bus_gnt[1];
-  assign fc_ctrl_slave.r_opc   = s_ctrl_bus_r_opc[1];
-  assign fc_ctrl_slave.r_valid = s_ctrl_bus_r_valid[1];
-  assign fc_ctrl_slave.r_rdata = s_ctrl_bus_r_rdata[1];
-  assign fc_ctrl_slave.r_id    = s_ctrl_bus_r_id[1];
+  assign s_ctrl_bus_add[NB_CORES+1]     = fc_ctrl_slave.add;
+  assign s_ctrl_bus_req[NB_CORES+1]     = fc_ctrl_slave.req;
+  assign s_ctrl_bus_wdata[NB_CORES+1]   = fc_ctrl_slave.wdata;
+  assign s_ctrl_bus_wen[NB_CORES+1]     = fc_ctrl_slave.wen;
+  assign s_ctrl_bus_be[NB_CORES+1]      = fc_ctrl_slave.be;
+  assign s_ctrl_bus_id[NB_CORES+1]      = fc_ctrl_slave.id;
+  assign fc_ctrl_slave.gnt     = s_ctrl_bus_gnt[NB_CORES+1];
+  assign fc_ctrl_slave.r_opc   = s_ctrl_bus_r_opc[NB_CORES+1];
+  assign fc_ctrl_slave.r_valid = s_ctrl_bus_r_valid[NB_CORES+1];
+  assign fc_ctrl_slave.r_rdata = s_ctrl_bus_r_rdata[NB_CORES+1];
+  assign fc_ctrl_slave.r_id    = s_ctrl_bus_r_id[NB_CORES+1];
 
   generate
     for (genvar i=0; i<4; i++) begin : TCDM_MASTER_BIND
@@ -129,7 +140,7 @@ module dmac_wrap
    
   mchan #(
 
-    .NB_CTRLS                 ( NB_CTRLS                     ),    // NUMBER OF CONTROL PORTS : CL, FC, DECOMPRESSOR
+    .NB_CTRLS                 ( NB_CTRLS                     ),    // NUMBER OF CONTROL PORTS : 8 CORES, CL, FC
     //.NB_TRANSFERS             ( 16                    ),    // NUMBER OF AVAILABLE DMA CHANNELS
     //.CTRL_TRANS_QUEUE_DEPTH   ( 2                     ),    // DEPTH OF PRIVATE PER-CORE COMMAND QUEUE (CTRL_UNIT)
     //.GLOBAL_TRANS_QUEUE_DEPTH ( 8                     ),    // DEPTH OF GLOBAL COMMAND QUEUE (CTRL_UNIT)
@@ -253,8 +264,8 @@ module dmac_wrap
     .axi_master_b_user_i       ( ext_master.b_user                  ),
     .axi_master_b_ready_o      ( ext_master.b_ready                 ),
 
-    .term_evt_o                ( {term_event_pe_o,term_event_cl_o}     ),
-    .term_int_o                ( {term_irq_pe_o,term_irq_cl_o    }     ),
+    .term_evt_o                ( {term_event_pe_o,term_event_cl_o,term_event_o}     ),
+    .term_int_o                ( {term_irq_pe_o,term_irq_cl_o,term_irq_o      }     ),
 
     .busy_o                    ( busy_o                             )
   );

--- a/rtl/periph_demux.sv
+++ b/rtl/periph_demux.sv
@@ -1,0 +1,178 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/*
+ * periph_demux.sv
+ * Davide Rossi <davide.rossi@unibo.it>
+ * Antonio Pullini <pullinia@iis.ee.ethz.ch>
+ * Igor Loi <igor.loi@unibo.it>
+ * Francesco Conti <fconti@iis.ee.ethz.ch>
+ */
+
+`include "pulp_soc_defines.sv"
+
+module periph_demux
+#(
+  parameter ADDR_WIDTH = 32,
+  parameter DATA_WIDTH = 32,
+  parameter BE_WIDTH = DATA_WIDTH/8
+)
+(
+  input  logic                    clk,
+  input  logic                    rst_ni,
+
+  // CORE SIDE
+  input  logic                    data_req_i,
+  input  logic [ADDR_WIDTH - 1:0] data_add_i,
+  input  logic                    data_wen_i,
+  input  logic [DATA_WIDTH - 1:0] data_wdata_i,
+  input  logic [BE_WIDTH - 1:0]   data_be_i,
+  output logic                    data_gnt_o,
+
+  output logic                    data_r_valid_o, // Data Response Valid (For LOAD/STORE commands)
+  output logic [DATA_WIDTH - 1:0] data_r_rdata_o, // Data Response DATA (For LOAD commands)
+  output logic                    data_r_opc_o,   // Data Response Error
+
+  // Low Latency log interconnect SIDE
+  output logic                    data_req_o_MH,
+  output logic [ADDR_WIDTH - 1:0] data_add_o_MH,
+  output logic                    data_wen_o_MH,
+  output logic [DATA_WIDTH - 1:0] data_wdata_o_MH,
+  output logic [BE_WIDTH - 1:0]   data_be_o_MH,
+  input  logic                    data_gnt_i_MH,
+  input  logic                    data_r_valid_i_MH,
+  input  logic [DATA_WIDTH - 1:0] data_r_rdata_i_MH,
+  input  logic                    data_r_opc_i_MH,
+
+  //low latency event unit access, sleep_req,clear buffer_req
+  output logic                    data_req_o_EU,
+  output logic [ADDR_WIDTH - 1:0] data_add_o_EU,
+  output logic                    data_wen_o_EU,
+  output logic [DATA_WIDTH - 1:0] data_wdata_o_EU,
+  output logic [BE_WIDTH - 1:0]   data_be_o_EU,
+  input  logic                    data_gnt_i_EU,
+  input  logic                    data_r_valid_i_EU,
+  input  logic [DATA_WIDTH - 1:0] data_r_rdata_i_EU,
+  input  logic                    data_r_opc_i_EU
+);
+
+  enum logic [1:0] {MH, EU, UNMAPPED } request_destination;
+
+  always_ff @(posedge clk, negedge rst_ni) begin : _UPDATE_RESPONSE_DESTINATION_
+    if(rst_ni == 1'b0) begin
+      request_destination <= MH;
+    end
+    else begin
+      if(data_req_i) begin
+`ifdef DEM_PER_BEFORE_TCDM_TS
+        case(data_add_i[13:10])
+          4'b1111 : begin : _EVENT_UNIT_REGS
+            request_destination <= EU; 
+          end
+          4'b1110 : begin : _MCHAN_REGISTERS_
+            request_destination <= MH;
+          end
+          default: begin : _UNMAPPED_REGION_
+            request_destination <= UNMAPPED; 
+          end
+        endcase // data_add_i[13:10]
+`else /* ! DEM_PER_BEFORE_TCDM_TS */
+        if( (data_add_i[19:14] == 6'b000001 ) ) begin // this means 0x1020_4000 to 1020_7FFF
+          case(data_add_i[13:10])
+            0 : begin : _EVENT_UNIT_REGS
+              request_destination <= EU; 
+            end
+            1 : begin : _MCHAN_REGISTERS_
+              request_destination <= MH; 
+            end
+            default : begin : _UNMAPPED_REGION_
+              request_destination <= UNMAPPED; 
+            end
+          endcase // data_add_i[10:13]
+        end
+`endif
+      end
+    end 
+  end
+
+  assign data_add_o_MH    = data_add_i;
+  assign data_wen_o_MH    = data_wen_i;
+  assign data_wdata_o_MH  = data_wdata_i;
+  assign data_be_o_MH     = data_be_i;
+
+  assign data_add_o_EU    = data_add_i;
+  assign data_wen_o_EU    = data_wen_i;
+  assign data_wdata_o_EU  = data_wdata_i;
+  assign data_be_o_EU     = data_be_i;
+
+  always_comb
+  begin : _HANDLE_REQ_
+    data_req_o_MH = 1'b0;
+    data_req_o_EU = 1'b0;
+    data_gnt_o    = 1'b0;
+`ifdef DEM_PER_BEFORE_TCDM_TS
+    case(data_add_i[13:10])
+      4'b1111 : begin
+        data_req_o_EU = data_req_i;
+        data_gnt_o    = data_gnt_i_EU;
+      end
+      4'b1110 : begin
+        data_req_o_MH = data_req_i;
+        data_gnt_o    = data_gnt_i_MH;
+      end
+      default : begin : _TO_UNMAPPED_REGION_
+        data_req_o_MH = 1'b0;
+        data_req_o_EU = 1'b0;
+        data_gnt_o    = 1'b0;
+      end
+    endcase // data_add_i[13:10]
+`else /* ! DEM_PER_BEFORE_TCDM_TS */
+    if( (data_add_i[19:14] == 6'b000001 ) ) begin // this means 0x1020_4000 to 1020_7FFF
+      case(data_add_i[13:10])
+        0 : begin
+          data_req_o_EU = data_req_i;
+          data_gnt_o    = data_gnt_i_EU;
+        end
+        1 : begin
+          data_req_o_MH = data_req_i;
+          data_gnt_o    = data_gnt_i_MH;
+        end
+        default : begin
+          data_req_o_MH    = 1'b0;
+          data_req_o_EU    = 1'b0;
+          data_gnt_o       = 1'b0; 
+        end
+      endcase // data_add_i[10:13]
+    end
+`endif
+  end
+
+  always_comb
+  begin : _HANDLE_RESP_
+    case(request_destination)
+      MH : begin : _RESP_FROM_MCHAN_
+        data_r_valid_o = data_r_valid_i_MH;
+        data_r_rdata_o = data_r_rdata_i_MH;
+        data_r_opc_o   = 1'b0;
+      end
+      EU : begin : _RESP_FROM_EVENT_UNIT_
+        data_r_valid_o = data_r_valid_i_EU;
+        data_r_rdata_o = data_r_rdata_i_EU;
+        data_r_opc_o   = 1'b0;
+      end
+      default : begin : _UNMAPPED_RESP_
+        data_r_valid_o = 1'b0;
+        data_r_rdata_o = '0;
+        data_r_opc_o   = 1'b0;
+      end
+    endcase
+  end
+
+endmodule

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -353,7 +353,8 @@ module pulp_cluster
   logic                                       s_dma_cl_irq;
   logic                                       s_dma_fc_event;
   logic                                       s_dma_fc_irq;
-
+   
+  
   logic                                       s_dma_decompr_event;
   logic                                       s_dma_decompr_irq;
 
@@ -423,7 +424,7 @@ module pulp_cluster
   
   /* other interfaces */
   // cores -> DMA ctrl
-  // XBAR_TCDM_BUS s_core_dmactrl_bus[NB_CORES-1:0]();
+  XBAR_TCDM_BUS s_core_dmactrl_bus[NB_CORES-1:0]();
   
   // cores -> event unit ctrl
   XBAR_PERIPH_BUS s_core_euctrl_bus[NB_CORES-1:0]();
@@ -738,7 +739,7 @@ module pulp_cluster
   //*************************************************** 
   
   dmac_wrap #(
-    .NB_CTRLS           ( 2                  ),
+    .NB_CTRLS           ( 10                 ),
     .NB_CORES           ( NB_CORES           ),
     .NB_OUTSND_BURSTS   ( NB_OUTSND_BURSTS   ),
     .MCHAN_BURST_LENGTH ( MCHAN_BURST_LENGTH ),
@@ -752,19 +753,21 @@ module pulp_cluster
     .ADDR_WIDTH         ( ADDR_WIDTH         ),
     .BE_WIDTH           ( BE_WIDTH           )
   ) dmac_wrap_i (
-    .clk_i          ( clk_cluster        ),
-    .rst_ni         ( rst_ni             ),
-    .test_mode_i    ( test_mode_i        ),
-    //.ctrl_slave     ( s_core_dmactrl_bus ), // eliminate
-    .cl_ctrl_slave  ( s_periph_dma_bus[0]),
-    .fc_ctrl_slave  ( s_periph_dma_bus[1]),
-    .tcdm_master    ( s_hci_dma          ),
-    .ext_master     ( s_dma_ext_bus      ),
-    .term_event_cl_o( s_dma_cl_event     ),
-    .term_irq_cl_o  ( s_dma_cl_irq       ),
-    .term_event_pe_o( s_dma_fc_event     ),
-    .term_irq_pe_o  ( s_dma_pe_irq       ),
-    .busy_o         ( s_dmac_busy        )
+    .clk_i             ( clk_cluster        ),
+    .rst_ni            ( rst_ni             ),
+    .test_mode_i       ( test_mode_i        ),
+    .ctrl_slave        ( s_core_dmactrl_bus ),
+    .cl_ctrl_slave     ( s_periph_dma_bus[0]),
+    .fc_ctrl_slave     ( s_periph_dma_bus[1]),
+    .tcdm_master       ( s_hci_dma          ),
+    .ext_master        ( s_dma_ext_bus      ),
+    .term_event_cl_o   ( s_dma_cl_event     ),
+    .term_irq_cl_o     ( s_dma_cl_irq       ),
+    .term_event_pe_o   ( s_dma_fc_event     ),
+    .term_irq_pe_o     ( s_dma_pe_irq       ),
+    .term_event_o      ( s_dma_event        ),
+    .term_irq_o        ( s_dma_irq          ),
+    .busy_o            ( s_dmac_busy        )
   );
 
   //***************************************************
@@ -805,8 +808,8 @@ module pulp_cluster
 
     .dma_cl_event_i         ( s_dma_cl_event                     ),
     .dma_cl_irq_i           ( s_dma_cl_irq                       ),
-    //.dma_events_i           ( s_dma_event                        ),
-    //.dma_irq_i              ( s_dma_irq                          ),
+    .dma_event_i            ( s_dma_event                        ),
+    .dma_irq_i              ( s_dma_irq                          ),
 
     // NEW_SIGNALS .decompr_done_evt_i     ( s_decompr_done_evt                 ),
 
@@ -938,7 +941,7 @@ module pulp_cluster
         .tcdm_data_master    ( s_hci_core[i]         ),
 
         //tcdm, dma ctrl unit, periph interco interfaces
-        //.dma_ctrl_master     ( s_core_dmactrl_bus[i] ),
+        .dma_ctrl_master     ( s_core_dmactrl_bus[i] ),
         .eu_ctrl_master      ( s_core_euctrl_bus[i]  ),
         .periph_data_master  ( s_core_periph_bus[i]  ),
       

--- a/src_files.yml
+++ b/src_files.yml
@@ -12,6 +12,7 @@ pulp_cluster:
     rtl/instr_width_converter.sv,
     rtl/core_region.sv,
     rtl/core_demux.sv,
+    rtl/periph_demux.sv,
     rtl/cluster_interconnect_wrap.sv,
     rtl/tcdm_banks_wrap.sv,
     rtl/per_demux_wrap.sv,


### PR DESCRIPTION
Added access to dma_wrap by every core_region through its periph_demux. When any core wants to write to the DMA, the XBAR_PER is now bypassed so that we avoid that extra latency cycle.

### For Cluster's Cores:
```
DMA Command Address = 0x10204400
DMA Status Reg = 0x10204404
```
### For FC:
```
DMA Command Address = 0x10201C00
DMA Status Reg  = 0x10201C04
```

New tests can be found [here](https://github.com/pulp-platform/regression_tests/tree/master/mchan_tests)