### PR TITLE
[pulp_cluster]: fix undriven dma pe irq valid signal

### DIFF
--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -313,7 +313,7 @@ module pulp_cluster
   logic                                       tcdm_sleep;
 
   logic               s_dma_pe_event;
-  logic               s_dma_pe_irq;
+  logic               s_dma_fc_irq;
   logic               s_pf_event;
   
   logic[NB_CORES-1:0][4:0] irq_id;
@@ -335,9 +335,6 @@ module pulp_cluster
   logic                                       s_dma_decompr_event;
   logic                                       s_dma_decompr_irq;
 
-  logic                                       s_decompr_done_evt;
-
-  assign s_dma_fc_irq = s_decompr_done_evt;
 
 
 
@@ -727,7 +724,7 @@ module pulp_cluster
     .term_event_cl_o   ( s_dma_cl_event     ),
     .term_irq_cl_o     ( s_dma_cl_irq       ),
     .term_event_pe_o   ( s_dma_fc_event     ),
-    .term_irq_pe_o     ( s_dma_pe_irq       ),
+    .term_irq_pe_o     ( s_dma_fc_irq       ),
     .term_event_o      ( s_dma_event        ),
     .term_irq_o        ( s_dma_irq          ),
     .busy_o            ( s_dmac_busy        )
@@ -773,8 +770,6 @@ module pulp_cluster
     .dma_cl_irq_i           ( s_dma_cl_irq                       ),
     .dma_event_i            ( s_dma_event                        ),
     .dma_irq_i              ( s_dma_irq                          ),
-
-    // NEW_SIGNALS .decompr_done_evt_i     ( s_decompr_done_evt                 ),
 
     .dma_fc_event_i         ( s_dma_fc_event                     ),
     .dma_fc_irq_i           (                                    ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -312,9 +312,6 @@ module pulp_cluster
   logic [1:0]                                 s_TCDM_arb_policy;
   logic                                       tcdm_sleep;
 
-  logic               s_dma_pe_event;
-  logic               s_dma_fc_irq;
-  logic               s_pf_event;
   
   logic[NB_CORES-1:0][4:0] irq_id;
   logic[NB_CORES-1:0][4:0] irq_ack_id;
@@ -331,9 +328,6 @@ module pulp_cluster
   logic                                       s_dma_fc_event;
   logic                                       s_dma_fc_irq;
    
-  
-  logic                                       s_dma_decompr_event;
-  logic                                       s_dma_decompr_irq;
 
 
 
@@ -1528,14 +1522,7 @@ module pulp_cluster
     .ack_i   ( dma_pe_irq_ack_i   ),
     .valid_o ( dma_pe_irq_valid_o )
   );
-   
-  // edge_propagator_tx ep_pf_evt_i (
-  //   .clk_i   ( clk_i          ),
-  //   .rstn_i  ( s_rst_n        ),
-  //   .valid_i ( s_pf_event     ),
-  //   .ack_i   ( pf_evt_ack_i   ),
-  //   .valid_o ( pf_evt_valid_o )
-  // );
+
    
   /* centralized gating */
   cluster_clock_gate #(


### PR DESCRIPTION
This fixes an undriven signal of the 'ep_dma_pe_irq_i' edge propagator. 
Removed unused event from the decompressor (we do not have this IP in the pulp cluster).
Regression TO BE RUN. 