### PR TITLE
fix: Correct AXI ID width for icache bus

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -24,7 +24,7 @@ dependencies:
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: 1.0.2 }
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
   tech_cells_generic:     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
-  cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "pulpissimo-v3.4.0-rev3"} # To be updated to openhwgroup repository
+  cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "pulpissimo-v3.4.0-rev4"}
   ibex:                   { git: "https://github.com/lowRISC/ibex.git", rev: "pulpissimo-v6.1.1" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: 1.0.1}
   hwpe-datamover-example: { git: "https://github.com/pulp-platform/hwpe-datamover-example.git", version: 1.0.1 }

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   cluster_interconnect:   { git: "https://github.com/pulp-platform/cluster_interconnect.git", version: 1.1.1 }
   event_unit_flex:        { git: "https://github.com/pulp-platform/event_unit_flex.git", rev: "1.4.1" }
   mchan:                  { git: "https://github.com/pulp-platform/mchan.git", version: 1.2.3 }
-  hier-icache:            { git: "https://github.com/pulp-platform/hier-icache.git", rev: "axi_node_dep" }
+  hier-icache:            { git: "https://github.com/pulp-platform/hier-icache.git", rev: "c82025995fbb18e045bb14ad2e94b35734994956" }
   icache_mp_128_pf:       { git: "https://github.com/pulp-platform/icache_mp_128_pf.git", rev: "6f2e54102001230db9c82432bf9e011842419a48" }
   # icache_private:         { git: "https://github.com/pulp-platform/icache_private.git", rev: "1d4cdbcbec3ab454c09d378fc55631b60450fccd" }
   cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", version: 2.1.0 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - ibex implementation
 - ID compliance of tcdm_banks
+- Correct AXI ID width for icache bus
 
 ## [2.0.0] - 2021-05-20
 - Initial version prior to Changelog

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -488,7 +488,7 @@ module pulp_cluster
   AXI_BUS #(
     .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH     ),
     .AXI_DATA_WIDTH ( AXI_DATA_C2S_WIDTH ),
-    .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH   ),
+    .AXI_ID_WIDTH   ( AXI_ID_IN_WIDTH    ),
     .AXI_USER_WIDTH ( AXI_USER_WIDTH     )
   ) s_core_instr_bus(); 
 
@@ -1088,7 +1088,7 @@ module pulp_cluster
     .PRI_CACHE_SIZE       ( 512                 ), //= 512,     // in Byte
     .PRI_CACHE_LINE       ( 1                   ), //= 1,       // in word of [PRI_FETCH_DATA_WIDTH]
 
-    .AXI_ID               ( AXI_ID_OUT_WIDTH    ), //= 6,
+    .AXI_ID               ( AXI_ID_IN_WIDTH     ), //= 6,
     .AXI_ADDR             ( AXI_ADDR_WIDTH      ), //= 32,
     .AXI_USER             ( AXI_USER_WIDTH      ), //= 6,
     .AXI_DATA             ( AXI_DATA_C2S_WIDTH  ), //= 64,
@@ -1181,7 +1181,7 @@ module pulp_cluster
     .NB_WAYS          ( SET_ASSOCIATIVE    ),
     .CACHE_SIZE       ( CACHE_SIZE         ),
     .CACHE_LINE       ( 1                  ),
-    .AXI_ID           ( AXI_ID_OUT_WIDTH   ),
+    .AXI_ID           ( AXI_ID_IN_WIDTH    ),
     .AXI_ADDR         ( AXI_ADDR_WIDTH     ),
     .AXI_USER         ( AXI_USER_WIDTH     ),
     .AXI_DATA         ( AXI_DATA_C2S_WIDTH ),
@@ -1279,7 +1279,7 @@ module pulp_cluster
     .USE_REDUCED_TAG       ( USE_REDUCED_TAG   ),
 
     //AXI PARAMETER
-    .AXI_ID                ( AXI_ID_OUT_WIDTH  ),
+    .AXI_ID                ( AXI_ID_IN_WIDTH   ),
     .AXI_USER              ( AXI_USER_WIDTH    ),
     .AXI_DATA              ( AXI_DATA_C2S_WIDTH    ),
     .AXI_ADDR              ( AXI_ADDR_WIDTH    )


### PR DESCRIPTION
The icache is connected as a master to the xbar, and should therefore use that ID width. An update to hier-icache removed hardcoded ID widths, relying instead on the parameters provided, which results in a non-functional system if bad ID widths are passed. This PR fixes it.