### PR TITLE
Updated fpu_interco and riscv_nn

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -105,7 +105,7 @@ packages:
     dependencies:
     - common_cells
   fpu_interco:
-    revision: 0769976fa51bdd820656a01161a4c46b88c59ac5
+    revision: c985d54c2b078ddfbec8c2a498f453410bbdc93e
     version: null
     source:
       Git: https://github.com/pulp-platform/fpu_interco.git
@@ -224,7 +224,7 @@ packages:
     - common_cells
     - common_verification
   riscv:
-    revision: 4eac53237c6d0062715d17016fe95462eb81ebc3
+    revision: 6187537f9994d16bad2d721c0f5ebc5193c0f010
     version: null
     source:
       Git: git@github.com:AlSaqr-platform/riscv_nn.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ dependencies:
   tech_cells_generic:     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
   riscv:                  { git: "git@github.com:AlSaqr-platform/riscv_nn.git", rev: 6187537f9994d16bad2d721c0f5ebc5193c0f010 } # branch: yt/hmr
   cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: 9b77611 } # `michaero/safety-island-clic` branch
-  ibex:                   { git: "https://github.com/lowRISC/ibex.git", rev: "pulpissimo-v6.1.1" }
+  ibex:                   { git: "https://github.com/pulp-platform/ibex.git", rev: "pulpissimo-v6.1.2" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", rev: f7b51416f3c407e4c31e9c016616d57aae2687bd } # branch: yt/bump-clkgating
   hci:                    { git: "https://github.com/pulp-platform/hci.git", rev: b2e6f391aa6c10c03f45b693d80a0aaddecf169b } # branch: master
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746  } # branch: master

--- a/Bender.yml
+++ b/Bender.yml
@@ -21,13 +21,13 @@ dependencies:
   idma:                   { git: "https://github.com/pulp-platform/iDMA.git", rev: 437ffa9dac5dea0daccfd3e8ae604d4f6ae2cdf1 } # branch: master
   hier-icache:            { git: "https://github.com/pulp-platform/hier-icache.git", rev: "a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be" } # branch: yt/carfield
   cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", rev: a596f17fc77713909bceb7eecf3ea2c3cdfe707c } # branch: yt/bump-hci
-  fpu_interco:            { git: "https://github.com/pulp-platform/fpu_interco.git", rev: "0769976fa51bdd820656a01161a4c46b88c59ac5" } # branch: yt/carfield
+  fpu_interco:            { git: "https://github.com/pulp-platform/fpu_interco.git", rev: "c985d54c2b078ddfbec8c2a498f453410bbdc93e" } # branch: yt/carfield
   axi:                    { git: "https://github.com/pulp-platform/axi.git", version: =0.39.0-beta.9  }
   axi_slice:              { git: "https://github.com/pulp-platform/axi_slice.git", version: 1.1.4 } # deprecated, replaced by axi_cut (in axi repo)
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: 1.0.2 }
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
   tech_cells_generic:     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
-  riscv:                  { git: "git@github.com:AlSaqr-platform/riscv_nn.git", rev: 4eac53237c6d0062715d17016fe95462eb81ebc3 } # branch: yt/hmr
+  riscv:                  { git: "git@github.com:AlSaqr-platform/riscv_nn.git", rev: 6187537f9994d16bad2d721c0f5ebc5193c0f010 } # branch: yt/hmr
   cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: 9b77611 } # `michaero/safety-island-clic` branch
   ibex:                   { git: "https://github.com/lowRISC/ibex.git", rev: "pulpissimo-v6.1.1" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", rev: f7b51416f3c407e4c31e9c016616d57aae2687bd } # branch: yt/bump-clkgating

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1395,7 +1395,7 @@ axi_cdc_src #(
  .axi_req_t  ( c2s_req_t     ),
  .axi_resp_t ( c2s_resp_t    ),
  .LogDepth   ( LOG_DEPTH     ),
- .SyncStages ( CDC_SYNC_STAGES ),
+ .SyncStages ( CDC_SYNC_STAGES )
 ) axi_master_cdc_i (
  .src_rst_ni                       ( pwr_on_rst_ni               ),
  .src_clk_i                        ( clk_i                       ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -86,6 +86,7 @@ module pulp_cluster
   parameter AXI_STRB_S2C_WIDTH      = AXI_DATA_S2C_WIDTH/8,
   parameter DC_SLICE_BUFFER_WIDTH   = 8,
   parameter LOG_DEPTH               = 3,
+  parameter CDC_SYNC_STAGES         = 2,
   parameter logic [AXI_ADDR_WIDTH-1:0] BaseAddr = 'h10000000,
   parameter logic [AXI_ADDR_WIDTH-1:0] ClusterPeripheralsOffs = 'h00200000,
   parameter logic [AXI_ADDR_WIDTH-1:0] ClusterExternalOffs    = 'h00400000,
@@ -1393,7 +1394,8 @@ axi_cdc_src #(
  .ar_chan_t  ( c2s_ar_chan_t ),
  .axi_req_t  ( c2s_req_t     ),
  .axi_resp_t ( c2s_resp_t    ),
- .LogDepth   ( LOG_DEPTH     )
+ .LogDepth   ( LOG_DEPTH     ),
+ .SyncStages ( CDC_SYNC_STAGES ),
 ) axi_master_cdc_i (
  .src_rst_ni                       ( pwr_on_rst_ni               ),
  .src_clk_i                        ( clk_i                       ),
@@ -1440,7 +1442,8 @@ axi_cdc_dst #(
   .ar_chan_t (s2c_ar_chan_t),
   .axi_req_t (s2c_req_t    ),
   .axi_resp_t(s2c_resp_t   ),
-  .LogDepth       ( LOG_DEPTH              )
+  .LogDepth       ( LOG_DEPTH              ),
+  .SyncStages     ( CDC_SYNC_STAGES        )
 ) axi_slave_cdc_i (
   .dst_rst_ni                       ( pwr_on_rst_ni              ),
   .dst_clk_i                        ( clk_i                      ),


### PR DESCRIPTION
fpu_interco : This commit is direct patch of the previously used `0769976fa`
https://github.com/pulp-platform/fpu_interco/commit/c985d54c2b078ddfbec8c2a498f453410bbdc93e

riscv_nn as well:
**See PR :**
https://github.com/AlSaqr-platform/riscv_nn/pull/1