### PR TITLE
Dismiss obsolete icache code.

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -19,8 +19,6 @@ dependencies:
   event_unit_flex:        { git: "https://github.com/pulp-platform/event_unit_flex.git", rev: "1.4.1" }
   mchan:                  { git: "https://github.com/pulp-platform/mchan.git", version: 1.2.3 }
   hier-icache:            { git: "https://github.com/pulp-platform/hier-icache.git", rev: "fc231dfc9559c6715c3577049eae3d1887282cb0" }
-  # icache_mp_128_pf:       { git: "https://github.com/pulp-platform/icache_mp_128_pf.git", rev: "6f2e54102001230db9c82432bf9e011842419a48" }
-  # icache_private:         { git: "https://github.com/pulp-platform/icache_private.git", rev: "1d4cdbcbec3ab454c09d378fc55631b60450fccd" }
   cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", version: 2.1.0 }
   fpu_interco:            { git: "https://github.com/pulp-platform/fpu_interco.git", rev: "66b4084117546d5b748c30b5500769805f489d2f" }
   axi:                    { git: "https://github.com/pulp-platform/axi.git", version: 0.39.1  }

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -61,8 +61,6 @@ module cluster_peripherals
   XBAR_PERIPH_BUS.Master              dma_cfg_master[1:0],
   input logic                         dma_cl_event_i,
   input logic                         dma_cl_irq_i,
-  //input  logic                        dma_pe_irq_i,
-  //output logic                        pf_event_o,
  
   input logic                         dma_fc_event_i,
   input logic                         dma_fc_irq_i,
@@ -93,32 +91,13 @@ module cluster_peripherals
   XBAR_PERIPH_BUS.Master              hwpe_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
-  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o   
-                                
-  //output logic [NB_L1_CUTS-1:0][RW_MARGIN_WIDTH-1:0] rw_margin_L1_o,
+  output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
 
   // Control ports
-`ifdef PRIVATE_ICACHE
-  ,
   SP_ICACHE_CTRL_UNIT_BUS.Master       IC_ctrl_unit_bus_main[NB_CACHE_BANKS],
   PRI_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus_pri[NB_CORES],
   output logic [NB_CORES-1:0]          enable_l1_l15_prefetch_o
-`else
-  `ifdef SP_ICACHE
-    ,
-    // Control ports
-    SP_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus[NB_CACHE_BANKS],
-    L0_CTRL_UNIT_BUS.Master             L0_ctrl_unit_bus[NB_CORES]
-  `else
-    `ifdef MP_ICACHE
-      ,
-      MP_PF_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus
-    `endif
-  `endif
-`endif
- 
- 
-  );
+);
    
   logic                      s_timer_out_lo_event;
   logic                      s_timer_out_hi_event;
@@ -205,8 +184,6 @@ module cluster_peripherals
     .TCDM_arb_policy_o (TCDM_arb_policy_o          )
     //.rw_margin_L1_o    ( rw_margin_L1_o            )
   );
-  
-
 
   //********************************************************
   //******************** TIMER *****************************
@@ -248,8 +225,6 @@ module cluster_peripherals
     end
   endgenerate
 
-
-
   event_unit_top #(
     .NB_CORES     ( NB_CORES   ),
     .NB_BARR      ( NB_CORES   ),
@@ -286,15 +261,10 @@ module cluster_peripherals
     
     .message_master         ( eu_message_master      )
   );
-
   
   //********************************************************
   //******************** icache_ctrl_unit ******************
   //********************************************************
-  
-   
-
-`ifdef PRIVATE_ICACHE   //to be integrated hier_icache
    
   hier_icache_ctrl_unit_wrap #(
     .NB_CACHE_BANKS ( NB_CACHE_BANKS       ),
@@ -309,42 +279,7 @@ module cluster_peripherals
     .IC_ctrl_unit_bus_main       (  IC_ctrl_unit_bus_main           ),
     .enable_l1_l15_prefetch_o    (  enable_l1_l15_prefetch_o        )
   );
-   
-`else
- `ifdef MP_ICACHE
-  mp_pf_icache_ctrl_unit #(
-    .NB_CACHE_BANKS ( NB_CACHE_BANKS       ),
-    .NB_CORES       ( NB_CORES             ),
-    .ID_WIDTH       ( NB_CORES+NB_MPERIPHS ),
-    .FEATURE_STAT   ( FEATURE_STAT         )
-  ) icache_ctrl_unit_i (
-    .clk_i                       (  clk_i                           ),
-    .rst_ni                      (  rst_ni                          ),
 
-    .speriph_slave               (  speriph_slave[SPER_ICACHE_CTRL] ),
-    .IC_ctrl_unit_master_if      (  IC_ctrl_unit_bus                ),
-    .pf_event_o                  (                                  )
-  );
- `else
-  `ifdef SP_ICACHE
-  sp_icache_ctrl_unit #(
-    .NB_CACHE_BANKS ( NB_CACHE_BANKS       ),
-    .NB_CORES       ( NB_CORES             ),
-    .ID_WIDTH       ( NB_CORES+NB_MPERIPHS ),
-    .OFFSET         ( 4                    ),
-    .FEATURE_STAT   ( FEATURE_STAT         )
-  ) icache_ctrl_unit_i (
-    .clk_i                       (  clk_i                           ),
-    .rst_ni                      (  rst_ni                          ),
-
-    .speriph_slave               (  speriph_slave[SPER_ICACHE_CTRL] ),
-    .IC_ctrl_unit_master_if      (  IC_ctrl_unit_bus                ),
-    .L0_ctrl_unit_master_if      (  L0_ctrl_unit_bus                )
-  );
-  `endif
- `endif
-`endif
-   
   //********************************************************
   //******************** DMA CL CONFIG PORT ****************
   //********************************************************

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1123,6 +1123,7 @@ localparam int unsigned RW_MARGIN_WIDTH = 4;
     .IC_ctrl_unit_bus_pri   ( IC_ctrl_unit_bus_pri      ),
     .IC_ctrl_unit_bus_main  ( IC_ctrl_unit_bus_main     )
   );
+  assign s_core_instr_bus.aw_atop = '0;
 
   /* TCDM banks */
   tcdm_banks_wrap #(


### PR DESCRIPTION
SP and MP iCache have been completely replaced by the hierarchical. This PR is intended to cleanup the top level of PULP cluster to simplify the code and make it more readable.