### PR TITLE
Integrate RedMulE and NEureka as selectable HWPEs

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -3,8 +3,7 @@ overrides:
   register_interface  : { git: "https://github.com/pulp-platform/register_interface.git"  , rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746 } # branch: master
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
   cv32e40p            : { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # branch: michaero/safety-island-clic
-  # WIPs, to be removed
-  cluster_peripherals : { git: "https://github.com/pulp-platform/cluster_peripherals.git" , rev: 8a9f62dafb5ec23c6cd361847ff0047e12befca4 } # branch: rt/neureka-redmule-integration
-  neureka             : { git: "https://github.com/pulp-platform/neureka.git"             , rev: 3131e87c40118f75e11a1ff9bae60fe764336a19 } # branch: astral-4x4
-  hci                 : { git: "https://github.com/pulp-platform/hci.git"                 , rev: e47627c20b33bcaf4842c1add81fb888b4f12a9d } # branch: master
-  hwpe-stream         : { git: "https://github.com/pulp-platform/hwpe-stream.git"         , rev: bcb4435f802add732f557dc7fa1c6b5dd8854458 } # branch: master
+
+  # Temporarily left here to avoid conflicts
+  hwpe-stream         : { git: "https://github.com/pulp-platform/hwpe-stream.git"         , rev: 65c99a4a2f37a79acee800ab0151f67dfb1edef1 } # branch: master
+  hci                 : { git: "https://github.com/pulp-platform/hci.git", rev: e47627c20b33bcaf4842c1add81fb888b4f12a9d }

--- a/Bender.local
+++ b/Bender.local
@@ -2,3 +2,4 @@ overrides:
   axi                 : { git: "https://github.com/pulp-platform/axi.git"                 , version: =0.39.1 }
   register_interface  : { git: "https://github.com/pulp-platform/register_interface.git"  , rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746 } # branch: master
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
+  cv32e40p            : { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # branch: michaero/safety-island-clic

--- a/Bender.local
+++ b/Bender.local
@@ -3,6 +3,8 @@ overrides:
   register_interface  : { git: "https://github.com/pulp-platform/register_interface.git"  , rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746 } # branch: master
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
   cv32e40p            : { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # branch: michaero/safety-island-clic
-  cluster_peripherals : { git: "https://github.com/pulp-platform/cluster_peripherals.git" , rev: ab82a2c3e10b87b677932e0fa46fd93e6e5df547 } # branch: rt/neureka-redmule-integration
+  # WIPs, to be removed
+  cluster_peripherals : { git: "https://github.com/pulp-platform/cluster_peripherals.git" , rev: 8a9f62dafb5ec23c6cd361847ff0047e12befca4 } # branch: rt/neureka-redmule-integration
   neureka             : { git: "https://github.com/pulp-platform/neureka.git"             , rev: 3131e87c40118f75e11a1ff9bae60fe764336a19 } # branch: astral-4x4
-  hci                 : { git: "https://github.com/pulp-platform/hci.git"                 , rev: 9d266f61deff39e99d87350e671ace8909e696f4 } # branch: add-passthrough
+  hci                 : { git: "https://github.com/pulp-platform/hci.git"                 , rev: e47627c20b33bcaf4842c1add81fb888b4f12a9d } # branch: master
+  hwpe-stream         : { git: "https://github.com/pulp-platform/hwpe-stream.git"         , rev: bcb4435f802add732f557dc7fa1c6b5dd8854458 } # branch: master

--- a/Bender.local
+++ b/Bender.local
@@ -4,3 +4,5 @@ overrides:
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
   cv32e40p            : { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # branch: michaero/safety-island-clic
   cluster_peripherals : { git: "https://github.com/pulp-platform/cluster_peripherals.git" , rev: ab82a2c3e10b87b677932e0fa46fd93e6e5df547 } # branch: rt/neureka-redmule-integration
+  neureka             : { git: "https://github.com/pulp-platform/neureka.git"             , rev: 3131e87c40118f75e11a1ff9bae60fe764336a19 } # branch: astral-4x4
+  hci                 : { git: "https://github.com/pulp-platform/hci.git"                 , rev: 9d266f61deff39e99d87350e671ace8909e696f4 } # branch: add-passthrough

--- a/Bender.local
+++ b/Bender.local
@@ -3,3 +3,6 @@ overrides:
   register_interface  : { git: "https://github.com/pulp-platform/register_interface.git"  , rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746 } # branch: master
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
   cv32e40p            : { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # branch: michaero/safety-island-clic
+  cluster_peripherals : { git: "https://github.com/pulp-platform/cluster_peripherals.git" , rev: ab82a2c3e10b87b677932e0fa46fd93e6e5df547 } # branch: rt/neureka-redmule-integration
+  hwpe-ctrl           : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"           , rev: a5966201aeeb988d607accdc55da933a53c6a56e } # branch: master
+  redmule             : { git: "https://github.com/pulp-platform/redmule.git"             , rev: 10363c973f987963f27227332c6c6638289f3f9c } # branch: rt/neureka-redmule-integration

--- a/Bender.local
+++ b/Bender.local
@@ -4,5 +4,3 @@ overrides:
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
   cv32e40p            : { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # branch: michaero/safety-island-clic
   cluster_peripherals : { git: "https://github.com/pulp-platform/cluster_peripherals.git" , rev: ab82a2c3e10b87b677932e0fa46fd93e6e5df547 } # branch: rt/neureka-redmule-integration
-  hwpe-ctrl           : { git: "https://github.com/pulp-platform/hwpe-ctrl.git"           , rev: a5966201aeeb988d607accdc55da933a53c6a56e } # branch: master
-  redmule             : { git: "https://github.com/pulp-platform/redmule.git"             , rev: 10363c973f987963f27227332c6c6638289f3f9c } # branch: rt/neureka-redmule-integration

--- a/Bender.lock
+++ b/Bender.lock
@@ -176,7 +176,6 @@ packages:
     - hci
     - hwpe-ctrl
     - hwpe-stream
-    - zeroriscy
   per2axi:
     revision: 95bf23119b47fc171d9ed3734c431f71cffd9350
     version: null
@@ -244,10 +243,4 @@ packages:
     version: 1.0.3
     source:
       Git: https://github.com/pulp-platform/timer_unit.git
-    dependencies: []
-  zeroriscy:
-    revision: 8a6c00e899cb6c715dcd5a3a1a92263994fb634b
-    version: null
-    source:
-      Git: git@github.com:yvantor/ibex.git
     dependencies: []

--- a/Bender.lock
+++ b/Bender.lock
@@ -52,8 +52,8 @@ packages:
     dependencies:
     - hci
   common_cells:
-    revision: 2bd027cb87eaa9bf7d17196ec5f69864b35b630f
-    version: 1.32.0
+    revision: ad22699793d98ef714f120c6268fe92d096a61e1
+    version: 1.33.1
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:
@@ -125,8 +125,8 @@ packages:
     dependencies:
     - tech_cells_generic
   hwpe-stream:
-    revision: bcb4435f802add732f557dc7fa1c6b5dd8854458
-    version: null
+    revision: 65c99a4a2f37a79acee800ab0151f67dfb1edef1
+    version: 1.8.0
     source:
       Git: https://github.com/pulp-platform/hwpe-stream.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -45,7 +45,7 @@ packages:
     dependencies:
     - common_cells
   cluster_peripherals:
-    revision: ab82a2c3e10b87b677932e0fa46fd93e6e5df547
+    revision: 8a9f62dafb5ec23c6cd361847ff0047e12befca4
     version: null
     source:
       Git: https://github.com/pulp-platform/cluster_peripherals.git
@@ -97,7 +97,7 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 9d266f61deff39e99d87350e671ace8909e696f4
+    revision: e47627c20b33bcaf4842c1add81fb888b4f12a9d
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git
@@ -125,8 +125,8 @@ packages:
     dependencies:
     - tech_cells_generic
   hwpe-stream:
-    revision: 4c2ef8c33a6e2a8c88127e2153013d4f2dc3f448
-    version: 1.7.0
+    revision: bcb4435f802add732f557dc7fa1c6b5dd8854458
+    version: null
     source:
       Git: https://github.com/pulp-platform/hwpe-stream.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -97,7 +97,7 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 4823e503851eb7e8cc765a58621d767a01d6a77b
+    revision: 9d266f61deff39e99d87350e671ace8909e696f4
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git
@@ -168,7 +168,7 @@ packages:
     dependencies:
     - common_cells
   neureka:
-    revision: a002f52587418844fff60a2472bd834ffcd6af29
+    revision: 3131e87c40118f75e11a1ff9bae60fe764336a19
     version: null
     source:
       Git: https://github.com/pulp-platform/neureka.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -45,7 +45,7 @@ packages:
     dependencies:
     - common_cells
   cluster_peripherals:
-    revision: c9defcfb4f4e8733383b28a451c430783c2febbd
+    revision: ab82a2c3e10b87b677932e0fa46fd93e6e5df547
     version: null
     source:
       Git: https://github.com/pulp-platform/cluster_peripherals.git
@@ -118,7 +118,7 @@ packages:
     - scm
     - tech_cells_generic
   hwpe-ctrl:
-    revision: b7857919ea14b586901ff4282ad7749a3d50501e
+    revision: a5966201aeeb988d607accdc55da933a53c6a56e
     version: null
     source:
       Git: https://github.com/pulp-platform/hwpe-ctrl.git
@@ -167,6 +167,16 @@ packages:
       Git: https://github.com/pulp-platform/mchan.git
     dependencies:
     - common_cells
+  neureka:
+    revision: d9e4c3c38aa28b3149444840297100f7355ddc22
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/neureka.git
+    dependencies:
+    - hci
+    - hwpe-ctrl
+    - hwpe-stream
+    - zeroriscy
   per2axi:
     revision: 95bf23119b47fc171d9ed3734c431f71cffd9350
     version: null
@@ -175,7 +185,7 @@ packages:
     dependencies:
     - axi_slice
   redmule:
-    revision: 1b30b0b9a31afa702eb2d166d672ceda2f5d463a
+    revision: 10363c973f987963f27227332c6c6638289f3f9c
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule.git
@@ -234,4 +244,10 @@ packages:
     version: 1.0.3
     source:
       Git: https://github.com/pulp-platform/timer_unit.git
+    dependencies: []
+  zeroriscy:
+    revision: 8a6c00e899cb6c715dcd5a3a1a92263994fb634b
+    version: null
+    source:
+      Git: git@github.com:yvantor/ibex.git
     dependencies: []

--- a/Bender.lock
+++ b/Bender.lock
@@ -168,7 +168,7 @@ packages:
     dependencies:
     - common_cells
   neureka:
-    revision: d9e4c3c38aa28b3149444840297100f7355ddc22
+    revision: a002f52587418844fff60a2472bd834ffcd6af29
     version: null
     source:
       Git: https://github.com/pulp-platform/neureka.git
@@ -185,7 +185,7 @@ packages:
     dependencies:
     - axi_slice
   redmule:
-    revision: 10363c973f987963f27227332c6c6638289f3f9c
+    revision: 68999ccc922b10a5043bb98f67aaf3d8d8d59f3f
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746  } # branch: master
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git",  version: 1.29.0 }
   redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: c37bdb47339bf70e8323de8df14ea8bbeafb6583 } # branch: astral_rebase
-  redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: 1b30b0b9a31afa702eb2d166d672ceda2f5d463a } # branch: astral
+  redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: 68999ccc922b10a5043bb98f67aaf3d8d8d59f3f } # branch: astral
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: a002f52587418844fff60a2472bd834ffcd6af29 } # branch: astral
 
 export_include_dirs:

--- a/Bender.yml
+++ b/Bender.yml
@@ -20,7 +20,7 @@ dependencies:
   mchan:                  { git: "https://github.com/pulp-platform/mchan.git", rev: 7f064f205a3e0203e959b14773c4afecf56681ab } # branch: yt/fix-parametrization
   idma:                   { git: "https://github.com/pulp-platform/iDMA.git", rev: 437ffa9dac5dea0daccfd3e8ae604d4f6ae2cdf1 } # branch: master
   hier-icache:            { git: "https://github.com/pulp-platform/hier-icache.git", rev: "2886cb2a46cea3e2bd2d979b505d88fadfbe150c" } # branch: astral
-  cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", rev: c9defcfb4f4e8733383b28a451c430783c2febbd } # branch: astral
+  cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", rev: 8a9f62dafb5ec23c6cd361847ff0047e12befca4 } # branch: astral
   axi:                    { git: "https://github.com/pulp-platform/axi.git", version: =0.39.1-beta  }
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: 1.0.2 }
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
@@ -29,12 +29,12 @@ dependencies:
   cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # `michaero/safety-island-clic` branch
   ibex:                   { git: "https://github.com/pulp-platform/ibex.git", rev: "pulpissimo-v6.1.2" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", rev: 74426dee36f28ae1c02f7635cf844a0156145320 } # branch: yt/bump-clkgating
-  hci:                    { git: "https://github.com/pulp-platform/hci.git", rev: v1.1 }
+  hci:                    { git: "https://github.com/pulp-platform/hci.git", rev: e47627c20b33bcaf4842c1add81fb888b4f12a9d }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746  } # branch: master
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git",  version: 1.29.0 }
   redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: c37bdb47339bf70e8323de8df14ea8bbeafb6583 } # branch: astral_rebase
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: 68999ccc922b10a5043bb98f67aaf3d8d8d59f3f } # branch: astral
-  neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: a002f52587418844fff60a2472bd834ffcd6af29 } # branch: astral
+  neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: 3131e87c40118f75e11a1ff9bae60fe764336a19 } # branch: astral-4x4
 
 export_include_dirs:
   - include

--- a/Bender.yml
+++ b/Bender.yml
@@ -34,6 +34,7 @@ dependencies:
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git",  version: 1.29.0 }
   redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: c37bdb47339bf70e8323de8df14ea8bbeafb6583 } # branch: astral_rebase
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: 1b30b0b9a31afa702eb2d166d672ceda2f5d463a } # branch: astral
+  neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: d9e4c3c38aa28b3149444840297100f7355ddc22 } # branch: astral
 
 export_include_dirs:
   - include

--- a/Bender.yml
+++ b/Bender.yml
@@ -30,7 +30,7 @@ dependencies:
   ibex:                   { git: "https://github.com/pulp-platform/ibex.git", rev: "pulpissimo-v6.1.2" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", rev: 74426dee36f28ae1c02f7635cf844a0156145320 } # branch: yt/bump-clkgating
   hci:                    { git: "https://github.com/pulp-platform/hci.git", rev: e47627c20b33bcaf4842c1add81fb888b4f12a9d }
-  register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: 19163bb5191d2669a8cbc267cdd4ce8e60f20746  } # branch: master
+  register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.4  } # branch: master
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git",  version: 1.29.0 }
   redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: c37bdb47339bf70e8323de8df14ea8bbeafb6583 } # branch: astral_rebase
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: 68999ccc922b10a5043bb98f67aaf3d8d8d59f3f } # branch: astral

--- a/Bender.yml
+++ b/Bender.yml
@@ -34,7 +34,7 @@ dependencies:
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git",  version: 1.29.0 }
   redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: c37bdb47339bf70e8323de8df14ea8bbeafb6583 } # branch: astral_rebase
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: 1b30b0b9a31afa702eb2d166d672ceda2f5d463a } # branch: astral
-  neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: d9e4c3c38aa28b3149444840297100f7355ddc22 } # branch: astral
+  neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: a002f52587418844fff60a2472bd834ffcd6af29 } # branch: astral
 
 export_include_dirs:
   - include

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endef
 ######################
 
 NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/pulp-cluster-nonfree.git
-NONFREE_COMMIT ?= 99ab7cf5e5c69e134ef84ad3304138f6fa105dd8
+NONFREE_COMMIT ?= fe360697bcfab4caba3ad463b42d4d27ff618c5a
 
 nonfree-init:
 	git clone $(NONFREE_REMOTE) nonfree

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ nonfree-init:
 
 .PHONY: init
 
-init: checkout pulp-runtime regression-tests
+init: checkout
+	git submodule update --init --recursive
 
 .PHONY: checkout scripts/compile.tcl
 ## Checkout/update dependencies using Bender

--- a/packages/pulp_cluster_package.sv
+++ b/packages/pulp_cluster_package.sv
@@ -30,6 +30,19 @@ package pulp_cluster_package;
     IBEX
   } core_type_e;
 
+  // HWPE type
+  typedef enum byte_t {
+    REDMULE,
+    NEUREKA
+  } hwpe_type_e;
+
+  parameter MAX_NUM_HWPES = 8;
+
+  typedef struct packed {
+    hwpe_type_e [MAX_NUM_HWPES-1:0] HwpeList;
+    byte_t NumHwpes;
+  } hwpe_subsystem_cfg_t;
+
   // PULP cluster configuration
   typedef struct packed {
     // Type of core in the cluster
@@ -60,6 +73,8 @@ package pulp_cluster_package;
     byte_t TcdmNumBank;
     // Enable HWPEs
     bit HwpePresent;
+    // HWPEs selection and ID map
+    hwpe_subsystem_cfg_t HwpeCfg;
     // Number of memory ports available for HWPEs
     byte_t HwpeNumPorts;
     // Number if I$ banks
@@ -171,6 +186,7 @@ package pulp_cluster_package;
     TcdmSize: 64*1024,
     TcdmNumBank: 16,
     HwpePresent: 0,
+    HwpeCfg: '0,
     HwpeNumPorts: 0,
     iCacheNumBanks: 2,
     iCacheNumLines: 1,

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -53,7 +53,7 @@ module cluster_peripherals
 
   output logic                        busy_o,
 
-  XBAR_PERIPH_BUS.Slave               speriph_slave[NB_SPERIPHS-2:0], // SPER_EXT_ID NOT PLUGGED HERE 
+  XBAR_PERIPH_BUS.Slave               speriph_slave[NB_SPERIPHS-2:0], // SPER_EXT_ID NOT PLUGGED HERE
   XBAR_PERIPH_BUS.Slave               core_eu_direct_link[NB_CORES-1:0],
 
   input  logic [NB_CORES-1:0]         dma_event_i,
@@ -63,14 +63,14 @@ module cluster_peripherals
   XBAR_PERIPH_BUS.Master              dma_cfg_master[1:0],
   input logic                         dma_cl_event_i,
   input logic                         dma_cl_irq_i,
- 
+
   input logic                         dma_fc_event_i,
   input logic                         dma_fc_irq_i,
-  
+
   output logic                        soc_periph_evt_ready_o,
   input  logic                        soc_periph_evt_valid_i,
   input  logic [EVNT_WIDTH-1:0]       soc_periph_evt_data_i,
-  
+
 
   input  logic [NB_CORES-1:0]         dbg_core_halted_i,
   output logic [NB_CORES-1:0]         dbg_core_halt_o,
@@ -108,20 +108,20 @@ module cluster_peripherals
   PRI_ICACHE_CTRL_UNIT_BUS.Master      IC_ctrl_unit_bus_pri[NB_CORES-1:0],
   output logic [NB_CORES-1:0]          enable_l1_l15_prefetch_o
 );
-   
+
   logic                      s_timer_out_lo_event;
   logic                      s_timer_out_hi_event;
   logic                      s_timer_in_lo_event;
   logic                      s_timer_in_hi_event;
-  
+
   logic [NB_CORES-1:0][31:0] s_cluster_events;
   logic [NB_CORES-1:0][3:0]  s_acc_events;
   logic [NB_CORES-1:0][1:0]  s_timer_events;
   logic [NB_CORES-1:0][1:0]  s_dma_events;
-  
+
   logic [NB_CORES-1:0]  s_fetch_en_cc;
 
-  MESSAGE_BUS eu_message_master(); 
+  MESSAGE_BUS eu_message_master();
 
   logic [NB_SPERIPH_PLUGS_EU-1:0]             eu_speriph_plug_req;
   logic [NB_SPERIPH_PLUGS_EU-1:0][31:0]       eu_speriph_plug_add;
@@ -132,7 +132,7 @@ module cluster_peripherals
 
   logic soc_periph_evt_valid, soc_periph_evt_ready;
   logic [7:0] soc_periph_evt_data;
-   
+
   // internal speriph bus to combine multiple plugs to new event unit
   XBAR_PERIPH_BUS speriph_slave_eu_comb();
 
@@ -141,7 +141,7 @@ module cluster_peripherals
 `else
   localparam bit          FEATURE_STAT    = 1'b0;
 `endif
-  
+
   // decide between common or core-specific event sources
   generate
     for (genvar I=0; I<NB_CORES; I++) begin
@@ -155,7 +155,7 @@ module cluster_peripherals
       assign s_dma_events[I][1] = dma_irq_i[I];
     end
   endgenerate
-  
+
   assign fetch_enable_reg_o = s_fetch_en_cc;
 
   //********************************************************
@@ -203,7 +203,7 @@ module cluster_peripherals
   //********************************************************
   //******************** TIMER *****************************
   //********************************************************
-  
+
   cluster_timer_wrap #(
     .ID_WIDTH     ( NB_CORES+NB_MPERIPHS         )
   ) cluster_timer_wrap_i (
@@ -217,7 +217,7 @@ module cluster_peripherals
     .irq_hi_o     ( s_timer_out_hi_event         ),
     .busy_o       ( busy_o                       )
   );
-   
+
   //********************************************************
   //******************** NEW EVENT UNIT ********************
   //********************************************************
@@ -266,21 +266,21 @@ module cluster_peripherals
     .barrier_matched_o      ( barrier_matched_o      ),
     .core_busy_i            ( core_busy_i            ),
     .core_clock_en_o        ( core_clk_en_o          ),
-    
+
     .speriph_slave          ( speriph_slave[SPER_EVENT_U_ID]  ),
     .eu_direct_link         ( core_eu_direct_link    ),
-    
+
     .soc_periph_evt_valid_i ( soc_periph_evt_valid_i ),
     .soc_periph_evt_ready_o ( soc_periph_evt_ready_o ),
-    .soc_periph_evt_data_i  ( soc_periph_evt_data_i  ),  
-    
+    .soc_periph_evt_data_i  ( soc_periph_evt_data_i  ),
+
     .message_master         ( eu_message_master      )
   );
-  
+
   //********************************************************
   //******************** icache_ctrl_unit ******************
   //********************************************************
-   
+
   hier_icache_ctrl_unit_wrap #(
     .NB_CACHE_BANKS ( NB_CACHE_BANKS       ),
     .NB_CORES       ( NB_CORES             ),
@@ -288,7 +288,7 @@ module cluster_peripherals
   ) icache_ctrl_unit_i (
     .clk_i                       (  clk_i                           ),
     .rst_ni                      (  rst_ni                          ),
-    
+
     .speriph_slave               (  speriph_slave[SPER_ICACHE_CTRL] ),
     .IC_ctrl_unit_bus_pri        (  IC_ctrl_unit_bus_pri            ),
     .IC_ctrl_unit_bus_main       (  IC_ctrl_unit_bus_main           ),
@@ -328,7 +328,7 @@ module cluster_peripherals
   assign dma_cfg_master[1].wdata = speriph_slave[SPER_DMA_FC_ID].wdata;
   assign dma_cfg_master[1].be    = speriph_slave[SPER_DMA_FC_ID].be;
   assign dma_cfg_master[1].id    = speriph_slave[SPER_DMA_FC_ID].id;
-  
+
   //********************************************************
   //******************** HW ACC  ***************************
   //********************************************************
@@ -390,5 +390,5 @@ module cluster_peripherals
       end
     end
   endgenerate
-   
+
 endmodule // cluster_peripherals

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -93,12 +93,13 @@ module cluster_peripherals
 
   // SRAM SPEED REGULATION --> TCDM
   output logic [1:0]                  TCDM_arb_policy_o,
-                                    
+
   XBAR_PERIPH_BUS.Master              hwpe_cfg_master,
   XBAR_PERIPH_BUS.Master              hmr_cfg_master,
   XBAR_PERIPH_BUS.Master              tcdm_scrubber_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
+  output logic                        hwpe_sel_o,
   output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
 
   // Control ports
@@ -182,6 +183,7 @@ module cluster_peripherals
 
     // SRAM SPEED REGULATION --> TCDM
     .hwpe_en_o      ( hwpe_en_o                    ),
+    .hwpe_sel_o     ( hwpe_sel_o                   ),
     .hci_ctrl_o     ( hci_ctrl_o                   ),
 
     .fregfile_disable_o ( fregfile_disable_o       ),

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -22,6 +22,7 @@ import pulp_cluster_package::*;
 module cluster_peripherals
 #(
   parameter NB_CORES       = 8,
+  parameter NB_HWPES       = 8,
   parameter NB_MPERIPHS    = 1,
   parameter NB_CACHE_BANKS = 4,
   parameter NB_SPERIPHS    = 8,
@@ -99,7 +100,7 @@ module cluster_peripherals
   XBAR_PERIPH_BUS.Master              tcdm_scrubber_cfg_master,
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
-  output logic                        hwpe_sel_o,
+  output logic [$clog2(NB_HWPES)-1:0] hwpe_sel_o,
   output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
 
   // Control ports
@@ -163,6 +164,7 @@ module cluster_peripherals
   cluster_control_unit #(
     .PER_ID_WIDTH  ( NB_CORES+NB_MPERIPHS         ),
     .NB_CORES      ( NB_CORES                     ),
+    .NB_HWPES      ( NB_HWPES                     ),
     .ROM_BOOT_ADDR ( ROM_BOOT_ADDR                ),
     .BOOT_ADDR     ( BOOT_ADDR                    )
     //.NB_L1_CUTS      ( NB_L1_CUTS                 ),

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -18,22 +18,30 @@ import hci_package::*;
 module hwpe_subsystem
 #(
   parameter N_CORES       = 8,
+  parameter N_HWPES       = 1,
   parameter N_MASTER_PORT = 9,
   parameter ID_WIDTH      = 8,
-  parameter USE_RBE       = 0
+  parameter USE_RBE       = 0,
+  parameter DW            = DEFAULT_DW,
+  parameter AW            = DEFAULT_AW,
+  parameter OW            = AW
 )
 (
-  input  logic                    clk,
-  input  logic                    rst_n,
-  input  logic                    test_mode,
-  input  logic                    hwpe_en_i,
-  
-  hci_core_intf.master            hwpe_xbar_master,
-  XBAR_PERIPH_BUS.Slave           hwpe_cfg_slave,
+  input  logic                       clk,
+  input  logic                       rst_n,
+  input  logic                       test_mode,
+  input  logic                       hwpe_en_i,
+  input  logic [$clog2(N_HWPES)-1:0] hwpe_sel_i,
 
-  output logic [N_CORES-1:0][1:0] evt_o,
-  output logic                    busy_o
+  hci_core_intf.master               hwpe_xbar_master,
+  XBAR_PERIPH_BUS.Slave              hwpe_cfg_slave,
+
+  output logic [N_CORES-1:0][1:0]    evt_o,
+  output logic                       busy_o
 );
+
+  logic [N_HWPES-1:0] busy;
+  logic [N_HWPES-1:0][N_CORES-1:0][1:0] evt;
 
   logic hwpe_clk;
 
@@ -46,9 +54,21 @@ module hwpe_subsystem
 
   hwpe_ctrl_intf_periph #(
     .ID_WIDTH ( ID_WIDTH )
-  ) periph (
+  ) periph [N_HWPES-1:0] (
     .clk ( hwpe_clk )
   );
+
+  hci_core_intf #(
+    .DW ( DW ),
+    .AW ( AW ),
+    .OW ( OW )
+  ) tcdm [N_HWPES-1:0] (
+    .clk ( clk_i )
+  );
+
+  /////////////
+  // REDMULE //
+  /////////////
 
   redmule_top   #(
     .ID_WIDTH    ( ID_WIDTH         ),
@@ -58,24 +78,131 @@ module hwpe_subsystem
     .clk_i       ( hwpe_clk         ),
     .rst_ni      ( rst_n            ),
     .test_mode_i ( test_mode        ),
-    .busy_o      ( busy_o           ),
-    .evt_o       ( evt_o            ),
-    .tcdm        ( hwpe_xbar_master ),
-    .periph      ( periph           )
+    .busy_o      ( busy[0]          ),
+    .evt_o       ( evt[0]           ),
+    .tcdm        ( tcdm[0]          ),
+    .periph      ( periph[0]        )
   );
 
-  always_comb
-  begin
-    periph.req  = hwpe_cfg_slave.req;
-    periph.add  = hwpe_cfg_slave.add;
-    periph.wen  = hwpe_cfg_slave.wen;
-    periph.be   = hwpe_cfg_slave.be;
-    periph.data = hwpe_cfg_slave.wdata;
-    periph.id   = hwpe_cfg_slave.id;
+  /////////////
+  // NEUREKA //
+  /////////////
+
+  hci_core_intf #(
+    .DW ( DW ),
+    .AW ( AW ),
+    .OW ( OW )
+  ) unused_tcdm (
+    .clk ( clk_i )
+  );
+
+  // TODO: specify params in package
+  neureka_top #(
+    .ID      ( ID_WIDTH ),
+    .BW      ( N_MASTER_PORT*32 ),
+    .N_CORES ( N_CORES )
+  ) i_neureka (
+    // global signals
+    .clk_i       ( hwpe_clk    ),
+    .rst_ni      ( rst_n       ),
+    .test_mode_i ( test_mode   ),
+    // events
+    .evt_o       ( evt[1]      ),
+    .busy_o      ( busy[1]     ),
+    // tcdm master ports
+    .tcdm        ( tcdm[1]     ),
+    .tcdm_weight ( unused_tcdm ),
+    // periph slave port
+    .periph      ( periph[1]   )
+  );
+
+  // Bind unused target signals of tcdm_weight port
+  assign unused_tcdm.gnt     = 1'b1; // To be sure that unwanted reqs get granted nevertheless
+  assign unused_tcdm.r_data  = '0;
+  assign unused_tcdm.r_valid = '0;
+  assign unused_tcdm.r_opc   = '0;
+  assign unused_tcdm.r_user  = '0;
+
+  //////////////////
+  // HWPE CFG BUS //
+  //////////////////
+
+  // Initiator signals decoded according to `hwpe_sel_i`
+  for (genvar i = 0; i < N_HWPES; i++) begin
+    always_comb begin
+      periph[i].req  = (hwpe_sel_i == i) ? hwpe_cfg_slave.req   : '0;
+      periph[i].add  = (hwpe_sel_i == i) ? hwpe_cfg_slave.add   : '0;
+      periph[i].wen  = (hwpe_sel_i == i) ? hwpe_cfg_slave.wen   : '0;
+      periph[i].be   = (hwpe_sel_i == i) ? hwpe_cfg_slave.be    : '0;
+      periph[i].data = (hwpe_sel_i == i) ? hwpe_cfg_slave.wdata : '0;
+      periph[i].id   = (hwpe_sel_i == i) ? hwpe_cfg_slave.id    : '0;
+    end
   end
-  assign hwpe_cfg_slave.gnt     = periph.gnt;
-  assign hwpe_cfg_slave.r_rdata = periph.r_data;
-  assign hwpe_cfg_slave.r_valid = periph.r_valid;
-  assign hwpe_cfg_slave.r_id    = periph.r_id;
+
+  // Target signals muxed according to `hwpe_sel_i`
+  logic [N_HWPES-1:0]               periph_gnt;
+  logic [N_HWPES-1:0][31:0]         periph_r_rdata;
+  logic [N_HWPES-1:0]               periph_r_valid;
+  logic [N_HWPES-1:0][ID_WIDTH-1:0] periph_r_id;
+
+  for (genvar i = 0; i < N_HWPES; i++) begin
+      assign periph_gnt     [i] = periph[i].gnt;
+      assign periph_r_rdata [i] = periph[i].r_data;
+      assign periph_r_valid [i] = periph[i].r_valid;
+      assign periph_r_id    [i] = periph[i].r_id;
+  end
+
+  always_comb begin
+    hwpe_cfg_slave.gnt     = periph_gnt     [0];
+    hwpe_cfg_slave.r_rdata = periph_r_rdata [0];
+    hwpe_cfg_slave.r_valid = periph_r_valid [0];
+    hwpe_cfg_slave.r_id    = periph_r_id    [0];
+    for (int i = 1; i < N_HWPES; i++) begin
+      if (hwpe_sel_i == i) begin
+        hwpe_cfg_slave.gnt     = periph_gnt     [i];
+        hwpe_cfg_slave.r_rdata = periph_r_rdata [i];
+        hwpe_cfg_slave.r_valid = periph_r_valid [i];
+        hwpe_cfg_slave.r_id    = periph_r_id    [i];
+      end
+    end
+  end
+
+  //////////////////////
+  // HWPE XBAR MASTER //
+  //////////////////////
+
+  hci_core_mux_static #(
+    .NB_CHAN ( N_HWPES ),
+    .DW      ( DW      ),
+    .AW      ( AW      ),
+    .OW      ( OW      )
+  ) i_hwpe_hci_mux (
+
+    /* Internally unused */
+    .clk_i   ( hwpe_clk        ),
+    .rst_ni  ( rst_n           ),
+    .clear_i ( '0              ),
+    /*********************/
+
+    .sel_i  ( hwpe_sel_i       ),
+
+    .in     ( tcdm             ),
+    .out    ( hwpe_xbar_master )
+);
+
+//////////////////
+// EVT AND BUSY //
+//////////////////
+
+always_comb begin
+  evt_o  = evt[0];
+  busy_o = busy[0];
+  for (int i = 1; i < N_HWPES; i++) begin
+    if (hwpe_sel_i == i) begin
+      evt_o  = evt[i];
+      busy_o = busy[i];
+    end
+  end
+end
 
 endmodule

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -114,15 +114,16 @@ module hwpe_subsystem
   // HWPE CFG BUS //
   //////////////////
 
-  // Initiator signals decoded according to `hwpe_sel_i`
   for (genvar i = 0; i < N_HWPES; i++) begin
     always_comb begin
-      periph[i].req  = (hwpe_sel_i == i) ? hwpe_cfg_slave.req   : '0;
-      periph[i].add  = (hwpe_sel_i == i) ? hwpe_cfg_slave.add   : '0;
-      periph[i].wen  = (hwpe_sel_i == i) ? hwpe_cfg_slave.wen   : '0;
-      periph[i].be   = (hwpe_sel_i == i) ? hwpe_cfg_slave.be    : '0;
-      periph[i].data = (hwpe_sel_i == i) ? hwpe_cfg_slave.wdata : '0;
-      periph[i].id   = (hwpe_sel_i == i) ? hwpe_cfg_slave.id    : '0;
+      // Initiator signals decoded according to `hwpe_sel_i`
+      periph[i].req  = (hwpe_sel_i == i) ? hwpe_cfg_slave.req : '0;
+      // No muxing needed
+      periph[i].add  = hwpe_cfg_slave.add;
+      periph[i].wen  = hwpe_cfg_slave.wen;
+      periph[i].be   = hwpe_cfg_slave.be;
+      periph[i].data = hwpe_cfg_slave.wdata;
+      periph[i].id   = hwpe_cfg_slave.id;
     end
   end
 

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -63,7 +63,7 @@ module hwpe_subsystem
     .AW ( AW ),
     .OW ( OW )
   ) tcdm [N_HWPES-1:0] (
-    .clk ( clk_i )
+    .clk ( hwpe_clk )
   );
 
   /////////////

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -17,14 +17,13 @@ import hci_package::*;
 
 module hwpe_subsystem
 #(
-  parameter N_CORES       = 8,
-  parameter N_HWPES       = 1,
-  parameter N_MASTER_PORT = 9,
-  parameter ID_WIDTH      = 8,
-  parameter USE_RBE       = 0,
-  parameter DW            = DEFAULT_DW,
-  parameter AW            = DEFAULT_AW,
-  parameter OW            = AW
+  parameter int unsigned N_CORES       = 8,
+  parameter int unsigned N_HWPES       = 1,
+  parameter int unsigned N_MASTER_PORT = 9,
+  parameter int unsigned ID_WIDTH      = 8,
+  parameter int unsigned DW            = DEFAULT_DW,
+  parameter int unsigned AW            = DEFAULT_AW,
+  parameter int unsigned OW            = AW
 )
 (
   input  logic                       clk,

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -14,36 +14,43 @@
  */
 
 import hci_package::*;
+import pulp_cluster_package::*;
 
 module hwpe_subsystem
 #(
-  parameter int unsigned N_CORES       = 8,
-  parameter int unsigned N_HWPES       = 1,
-  parameter int unsigned N_MASTER_PORT = 9,
-  parameter int unsigned ID_WIDTH      = 8,
-  parameter int unsigned DW            = DEFAULT_DW,
-  parameter int unsigned AW            = DEFAULT_AW,
-  parameter int unsigned OW            = AW
+  parameter  hwpe_subsystem_cfg_t HWPE_CFG = '0,
+  parameter  int unsigned N_CORES          = 8,
+  parameter  int unsigned N_MASTER_PORT    = 9,
+  parameter  int unsigned ID_WIDTH         = 8,
+  parameter  int unsigned DW               = DEFAULT_DW,
+  parameter  int unsigned AW               = DEFAULT_AW,
+  parameter  int unsigned OW               = AW
 )
 (
-  input  logic                       clk,
-  input  logic                       rst_n,
-  input  logic                       test_mode,
-  input  logic                       hwpe_en_i,
-  input  logic [$clog2(N_HWPES)-1:0] hwpe_sel_i,
+  input  logic                             clk,
+  input  logic                             rst_n,
+  input  logic                             test_mode,
+  input  logic                             hwpe_en_i,
+  input  logic [$clog2(MAX_NUM_HWPES)-1:0] hwpe_sel_i,
 
-  hci_core_intf.master               hwpe_xbar_master,
-  XBAR_PERIPH_BUS.Slave              hwpe_cfg_slave,
+  hci_core_intf.master                     hwpe_xbar_master,
+  XBAR_PERIPH_BUS.Slave                    hwpe_cfg_slave,
 
-  output logic [N_CORES-1:0][1:0]    evt_o,
-  output logic                       busy_o
+  output logic [N_CORES-1:0][1:0]          evt_o,
+  output logic                             busy_o
 );
+
+  localparam int unsigned N_HWPES = HWPE_CFG.NumHwpes;
 
   logic [N_HWPES-1:0] busy;
   logic [N_HWPES-1:0][N_CORES-1:0][1:0] evt;
 
   logic [N_HWPES-1:0] hwpe_clk;
   logic [N_HWPES-1:0] hwpe_en_int;
+
+  logic [$clog2(N_HWPES)-1:0] hwpe_sel_int;
+
+  assign hwpe_sel_int = hwpe_sel_i[0+:$clog2(N_HWPES)];
 
   hwpe_ctrl_intf_periph #(
     .ID_WIDTH ( ID_WIDTH )
@@ -55,9 +62,11 @@ module hwpe_subsystem
     .OW ( OW )
   ) tcdm [N_HWPES-1:0] (.clk(clk));
 
-  for (genvar i = 0; i < N_HWPES; i++) begin
+  for (genvar i = 0; i < N_HWPES; i++) begin : gen_hwpe
+
     // HWPE specific enable
-    assign hwpe_en_int[i] = hwpe_en_i && (hwpe_sel_i == i);
+    assign hwpe_en_int[i] = hwpe_en_i && (hwpe_sel_int == i);
+
     // Clock gating cell
     tc_clk_gating i_hwpe_clock_gate (
       .clk_i     ( clk            ),
@@ -65,54 +74,61 @@ module hwpe_subsystem
       .test_en_i ( test_mode      ),
       .clk_o     ( hwpe_clk[i]    )
     );
+
+    // Generate desired HWPEs
+    if (HWPE_CFG.HwpeList[i] == REDMULE) begin : gen_redmule
+
+      /////////////
+      // REDMULE //
+      /////////////
+
+      redmule_top   #(
+        .ID_WIDTH    ( ID_WIDTH         ),
+        .N_CORES     ( N_CORES          ),
+        .DW          ( N_MASTER_PORT*32 )
+      ) i_redmule    (
+        .clk_i       ( hwpe_clk[i] ),
+        .rst_ni      ( rst_n       ),
+        .test_mode_i ( test_mode   ),
+        .busy_o      ( busy[i]     ),
+        .evt_o       ( evt[i]      ),
+        .tcdm        ( tcdm[i]     ),
+        .periph      ( periph[i]   )
+      );
+
+    end else if (HWPE_CFG.HwpeList[i] == NEUREKA) begin : gen_neureka
+
+      /////////////
+      // NEUREKA //
+      /////////////
+
+      neureka_top   #(
+        .PE_H        ( 4        ),
+        .PE_W        ( 4        ),
+        .ID          ( ID_WIDTH ),
+        .N_CORES     ( N_CORES  )
+      ) i_neureka    (
+        // global signals
+        .clk_i       ( hwpe_clk[i] ),
+        .rst_ni      ( rst_n       ),
+        .test_mode_i ( test_mode   ),
+        // events
+        .evt_o       ( evt[i]      ),
+        .busy_o      ( busy[i]     ),
+        // tcdm master ports
+        .tcdm        ( tcdm[i]     ),
+        // periph slave port
+        .periph      ( periph[i]   )
+      );
+
+    end
   end
-
-  /////////////
-  // REDMULE //
-  /////////////
-
-  redmule_top   #(
-    .ID_WIDTH    ( ID_WIDTH         ),
-    .N_CORES     ( N_CORES          ),
-    .DW          ( N_MASTER_PORT*32 )
-  ) i_redmule    (
-    .clk_i       ( hwpe_clk[0]      ),
-    .rst_ni      ( rst_n            ),
-    .test_mode_i ( test_mode        ),
-    .busy_o      ( busy[0]          ),
-    .evt_o       ( evt[0]           ),
-    .tcdm        ( tcdm[0]          ),
-    .periph      ( periph[0]        )
-  );
-
-  /////////////
-  // NEUREKA //
-  /////////////
-
-  neureka_top #(
-    .PE_H    ( 4        ),
-    .PE_W    ( 4        ),
-    .ID      ( ID_WIDTH ),
-    .N_CORES ( N_CORES  )
-  ) i_neureka (
-    // global signals
-    .clk_i       ( hwpe_clk[1] ),
-    .rst_ni      ( rst_n       ),
-    .test_mode_i ( test_mode   ),
-    // events
-    .evt_o       ( evt[1]      ),
-    .busy_o      ( busy[1]     ),
-    // tcdm master ports
-    .tcdm        ( tcdm[1]     ),
-    // periph slave port
-    .periph      ( periph[1]   )
-  );
 
   //////////////////
   // HWPE CFG BUS //
   //////////////////
 
-  // Target signals muxed according to `hwpe_sel_i`
+  // Target signals muxed according to `hwpe_sel_int`
   logic [N_HWPES-1:0]               periph_gnt;
   logic [N_HWPES-1:0][31:0]         periph_r_rdata;
   logic [N_HWPES-1:0]               periph_r_valid;
@@ -120,8 +136,8 @@ module hwpe_subsystem
 
   for (genvar i = 0; i < N_HWPES; i++) begin
     always_comb begin
-      // Initiator signals decoded according to `hwpe_sel_i`
-      periph[i].req  = (hwpe_sel_i == i) ? hwpe_cfg_slave.req : '0;
+      // Initiator signals decoded according to `hwpe_sel_int`
+      periph[i].req  = (hwpe_sel_int == i) ? hwpe_cfg_slave.req : '0;
       // No muxing needed
       periph[i].add  = hwpe_cfg_slave.add;
       periph[i].wen  = hwpe_cfg_slave.wen;
@@ -146,7 +162,7 @@ module hwpe_subsystem
     evt_o  = evt[0];
     busy_o = busy[0];
     for (int i = 1; i < N_HWPES; i++) begin
-      if (hwpe_sel_i == i) begin
+      if (hwpe_sel_int == i) begin
         // Config bus
         hwpe_cfg_slave.gnt     = periph_gnt     [i];
         hwpe_cfg_slave.r_rdata = periph_r_rdata [i];
@@ -176,7 +192,7 @@ module hwpe_subsystem
     .clear_i ( '0              ),
     /*********************/
 
-    .sel_i  ( hwpe_sel_i       ),
+    .sel_i  ( hwpe_sel_int     ),
 
     .in     ( tcdm             ),
     .out    ( hwpe_xbar_master )

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -109,7 +109,7 @@ module pulp_cluster
   input logic                                    pwr_on_rst_ni,
   input logic                                    pmu_mem_pwdn_i,
 
-  
+
   input logic [3:0]                              base_addr_i,
 
   input logic                                    test_mode_i,
@@ -119,20 +119,20 @@ module pulp_cluster
   input logic [5:0]                              cluster_id_i,
 
   input logic                                    fetch_en_i,
- 
+
   output logic                                   eoc_o,
-  
+
   output logic                                   busy_o,
 
   input  logic                                   axi_isolate_i,
   output logic                                   axi_isolated_o,
- 
+
   input logic                                    dma_pe_evt_ack_i,
   output logic                                   dma_pe_evt_valid_o,
 
   input logic                                    dma_pe_irq_ack_i,
   output logic                                   dma_pe_irq_valid_o,
-  
+
   input logic                                    pf_evt_ack_i,
   output logic                                   pf_evt_valid_o,
 
@@ -144,30 +144,30 @@ module pulp_cluster
   output logic [Cfg.AxiCdcLogDepth:0]            async_cluster_events_rptr_o,
   input  logic [AsyncEventDataWidth-1:0]         async_cluster_events_data_i,
 
- 
+
   // AXI4 SLAVE
   //***************************************
   // WRITE ADDRESS CHANNEL
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_aw_wptr_i,
   input  logic [AsyncInAwDatawidth-1:0]          async_data_slave_aw_data_i,
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_aw_rptr_o,
-                                           
-  // READ ADDRESS CHANNEL                  
+
+  // READ ADDRESS CHANNEL
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_ar_wptr_i,
   input  logic [AsyncInArDatawidth-1:0]          async_data_slave_ar_data_i,
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_ar_rptr_o,
-                                           
-  // WRITE DATA CHANNEL                    
+
+  // WRITE DATA CHANNEL
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_w_wptr_i,
   input  logic [AsyncInWDatawidth-1:0]           async_data_slave_w_data_i,
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_w_rptr_o,
-                                                   
-  // READ DATA CHANNEL                             
+
+  // READ DATA CHANNEL
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_r_wptr_o,
   output logic [AsyncInRDataWidth-1:0]           async_data_slave_r_data_o,
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_r_rptr_i,
-                                                   
-  // WRITE RESPONSE CHANNEL                        
+
+  // WRITE RESPONSE CHANNEL
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_b_wptr_o,
   output logic [AsyncInBDataWidth-1:0]           async_data_slave_b_data_o,
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_slave_b_rptr_i,
@@ -177,23 +177,23 @@ module pulp_cluster
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_aw_wptr_o,
   output logic [AsyncOutAwDataWidth-1:0]         async_data_master_aw_data_o,
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_aw_rptr_i,
-                                           
-  // READ ADDRESS CHANNEL                  
+
+  // READ ADDRESS CHANNEL
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_ar_wptr_o,
   output logic [AsyncOutArDataWidth-1:0]         async_data_master_ar_data_o,
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_ar_rptr_i,
-                                           
-  // WRITE DATA CHANNEL                    
+
+  // WRITE DATA CHANNEL
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_w_wptr_o,
   output logic [AsyncOutWDataWidth-1:0]          async_data_master_w_data_o,
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_w_rptr_i,
-                                                   
-  // READ DATA CHANNEL                             
+
+  // READ DATA CHANNEL
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_r_wptr_i,
   input  logic [AsyncOutRDataWidth-1:0]          async_data_master_r_data_i,
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_r_rptr_o,
-                                                   
-  // WRITE RESPONSE CHANNEL                        
+
+  // WRITE RESPONSE CHANNEL
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_wptr_i,
   input  logic [AsyncOutBDataWidth-1:0]          async_data_master_b_data_i,
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_rptr_o
@@ -295,7 +295,7 @@ logic                                       s_dma_fc_irq;
 logic [Cfg.NumCores-1:0] hmr_barrier_matched;
 logic [Cfg.NumCores-1:0] hmr_dmr_sw_resynch_req, hmr_tmr_sw_resynch_req;
 logic [Cfg.NumCores-1:0] hmr_dmr_sw_synch_req, hmr_tmr_sw_synch_req;
- 
+
 // FIXME: iDMA
 // logic                                       s_dma_decompr_event;
 // logic                                       s_dma_decompr_irq;
@@ -421,7 +421,7 @@ hci_mem_intf #(
 
 //***************************************************
 /* synchronous AXI interfaces at CLUSTER/SOC interface */
-//*************************************************** 
+//***************************************************
 AXI_BUS #(
   .AXI_ADDR_WIDTH ( Cfg.AxiAddrWidth    ),
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
@@ -441,24 +441,24 @@ AXI_BUS #(
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
   .AXI_ID_WIDTH   ( AxiIdOutWidth ),
   .AXI_USER_WIDTH ( Cfg.AxiUserWidth    )
-) s_data_master(); 
+) s_data_master();
 
 AXI_BUS #(
   .AXI_ADDR_WIDTH ( Cfg.AxiAddrWidth    ),
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
   .AXI_ID_WIDTH   ( AxiIdInWidth ),
   .AXI_USER_WIDTH ( Cfg.AxiUserWidth    )
-) s_core_instr_bus(); 
+) s_core_instr_bus();
 
 // ***********************************************************************************************+
 // ***********************************************************************************************+
 // ***********************************************************************************************+
 // ***********************************************************************************************+
 // ***********************************************************************************************+
- 
+
 //***************************************************
 /* synchronous AXI interfaces internal to the cluster */
-//*************************************************** 
+//***************************************************
 
 // core per2axi -> ext
 AXI_BUS #(
@@ -466,7 +466,7 @@ AXI_BUS #(
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
   .AXI_ID_WIDTH   ( AxiIdInWidth ),
   .AXI_USER_WIDTH ( Cfg.AxiUserWidth    )
-) s_core_ext_bus(); 
+) s_core_ext_bus();
 
 // DMA -> ext
 AXI_BUS #(
@@ -474,7 +474,7 @@ AXI_BUS #(
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
   .AXI_ID_WIDTH   ( AxiIdInWidth ),
   .AXI_USER_WIDTH ( Cfg.AxiUserWidth    )
-) s_dma_ext_bus(); 
+) s_dma_ext_bus();
 
 // ext -> axi2mem
 AXI_BUS #(
@@ -482,9 +482,9 @@ AXI_BUS #(
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
   .AXI_ID_WIDTH   ( AxiIdOutWidth ),
   .AXI_USER_WIDTH ( Cfg.AxiUserWidth    )
-) s_ext_tcdm_bus(); 
+) s_ext_tcdm_bus();
 
-// cluster bus -> axi2per 
+// cluster bus -> axi2per
 AXI_BUS #(
   .AXI_ADDR_WIDTH ( Cfg.AxiAddrWidth    ),
   .AXI_DATA_WIDTH ( Cfg.AxiDataOutWidth ),
@@ -593,7 +593,7 @@ per2axi_wrap #(
 
 //***************************************************
 /* cluster (log + periph) interconnect and attached peripherals */
-//*************************************************** 
+//***************************************************
 
 cluster_interconnect_wrap #(
   .NB_CORES               ( Cfg.NumCores           ),
@@ -640,7 +640,7 @@ cluster_interconnect_wrap #(
 
 //***************************************************
 //*********************DMAC WRAP*********************
-//*************************************************** 
+//***************************************************
 `ifdef TARGET_MCHAN
   dmac_wrap #(
     .NB_CTRLS           ( Cfg.NumCores + 2            ),
@@ -777,10 +777,10 @@ cluster_peripherals #(
   .hmr_sw_resynch_req_i   ( hmr_dmr_sw_resynch_req | hmr_tmr_sw_resynch_req ),
   .hmr_sw_synch_req_i     ( hmr_dmr_sw_synch_req | hmr_tmr_sw_synch_req ),
 
-  .fregfile_disable_o     ( s_fregfile_disable                 ),   
-  
+  .fregfile_disable_o     ( s_fregfile_disable                 ),
+
   .TCDM_arb_policy_o      ( s_TCDM_arb_policy                  ),
-  
+
   .hwpe_cfg_master          ( s_hwpe_cfg_bus                    ),
   .hwpe_events_i            ( s_hwpe_remap_evt                  ),
   .hwpe_en_o                ( s_hwpe_en                         ),
@@ -897,7 +897,7 @@ generate
       .irq_ack_o           ( core2hmr[i].irq_ack      ),
       .test_mode_i         ( test_mode_i              ),
       .core_busy_o         ( core2hmr[i].core_busy    ),
-      //instruction cache bind 
+      //instruction cache bind
       .instr_req_o         ( core2hmr[i].instr_req    ),
       .instr_gnt_i         ( hmr2core[i].instr_gnt    ),
       .instr_addr_o        ( core2hmr[i].instr_addr   ),
@@ -1384,7 +1384,7 @@ tcdm_banks_wrap  #(
   .tcdm_slave            ( s_tcdm_bus_sram          )  //PMU ??
 );
 
-/* AXI interconnect infrastructure (slices, size conversion) */ 
+/* AXI interconnect infrastructure (slices, size conversion) */
 //********************************************************
 //**************** AXI REGISTER SLICES *******************
 //********************************************************
@@ -1521,34 +1521,34 @@ axi_cdc_src  #(
  .LogDepth    ( Cfg.AxiCdcLogDepth   ),
  .SyncStages  ( Cfg.AxiCdcSyncStages )
 ) axi_master_cdc_i (
- .src_rst_ni                  ( pwr_on_rst_ni               ),
- .src_clk_i                   ( clk_i                       ),
- .src_req_i                   ( src_req                     ),
- .src_resp_o                  ( src_resp                    ),
- .async_data_master_aw_wptr_o ( async_data_master_aw_wptr_o ),   
- .async_data_master_aw_rptr_i ( async_data_master_aw_rptr_i ),
- .async_data_master_aw_data_o ( async_data_master_aw_data_o ),
- .async_data_master_w_wptr_o  ( async_data_master_w_wptr_o  ),
- .async_data_master_w_rptr_i  ( async_data_master_w_rptr_i  ),
- .async_data_master_w_data_o  ( async_data_master_w_data_o  ),
- .async_data_master_ar_wptr_o ( async_data_master_ar_wptr_o ),
- .async_data_master_ar_rptr_i ( async_data_master_ar_rptr_i ),
- .async_data_master_ar_data_o ( async_data_master_ar_data_o ),
- .async_data_master_b_wptr_i  ( async_data_master_b_wptr_i  ),
- .async_data_master_b_rptr_o  ( async_data_master_b_rptr_o  ),
- .async_data_master_b_data_i  ( async_data_master_b_data_i  ),
- .async_data_master_r_wptr_i  ( async_data_master_r_wptr_i  ),
- .async_data_master_r_rptr_o  ( async_data_master_r_rptr_o  ),
- .async_data_master_r_data_i  ( async_data_master_r_data_i  )  
+ .src_rst_ni                       ( pwr_on_rst_ni               ),
+ .src_clk_i                        ( clk_i                       ),
+ .src_req_i                        ( src_req                     ),
+ .src_resp_o                       ( src_resp                    ),
+ .async_data_master_aw_wptr_o      ( async_data_master_aw_wptr_o ),
+ .async_data_master_aw_rptr_i      ( async_data_master_aw_rptr_i ),
+ .async_data_master_aw_data_o      ( async_data_master_aw_data_o ),
+ .async_data_master_w_wptr_o       ( async_data_master_w_wptr_o  ),
+ .async_data_master_w_rptr_i       ( async_data_master_w_rptr_i  ),
+ .async_data_master_w_data_o       ( async_data_master_w_data_o  ),
+ .async_data_master_ar_wptr_o      ( async_data_master_ar_wptr_o ),
+ .async_data_master_ar_rptr_i      ( async_data_master_ar_rptr_i ),
+ .async_data_master_ar_data_o      ( async_data_master_ar_data_o ),
+ .async_data_master_b_wptr_i       ( async_data_master_b_wptr_i  ),
+ .async_data_master_b_rptr_o       ( async_data_master_b_rptr_o  ),
+ .async_data_master_b_data_i       ( async_data_master_b_data_i  ),
+ .async_data_master_r_wptr_i       ( async_data_master_r_wptr_i  ),
+ .async_data_master_r_rptr_o       ( async_data_master_r_rptr_o  ),
+ .async_data_master_r_data_i       ( async_data_master_r_data_i  )
 );
-    
+
 // SOC TO CLUSTER
 `AXI_TYPEDEF_AW_CHAN_T(s2c_aw_chan_t,logic[Cfg.AxiAddrWidth-1:0],logic[Cfg.AxiIdInWidth-1:0],logic[Cfg.AxiUserWidth-1:0])
 `AXI_TYPEDEF_W_CHAN_T(s2c_w_chan_t,logic[Cfg.AxiDataInWidth-1:0],logic[Cfg.AxiDataInWidth/8-1:0],logic[Cfg.AxiUserWidth-1:0])
 `AXI_TYPEDEF_B_CHAN_T(s2c_b_chan_t,logic[Cfg.AxiIdInWidth-1:0],logic[Cfg.AxiUserWidth-1:0])
 `AXI_TYPEDEF_AR_CHAN_T(s2c_ar_chan_t,logic[Cfg.AxiAddrWidth-1:0],logic[Cfg.AxiIdInWidth-1:0],logic[Cfg.AxiUserWidth-1:0])
 `AXI_TYPEDEF_R_CHAN_T(s2c_r_chan_t,logic[Cfg.AxiDataInWidth-1:0],logic[Cfg.AxiIdInWidth-1:0],logic[Cfg.AxiUserWidth-1:0])
- 
+
 `AXI_TYPEDEF_REQ_T(s2c_req_t,s2c_aw_chan_t,s2c_w_chan_t,s2c_ar_chan_t)
 `AXI_TYPEDEF_RESP_T(s2c_resp_t,s2c_b_chan_t,s2c_r_chan_t)
 
@@ -1566,25 +1566,25 @@ axi_cdc_dst   #(
   .LogDepth    ( Cfg.AxiCdcLogDepth   ),
   .SyncStages  ( Cfg.AxiCdcSyncStages )
 ) axi_slave_cdc_i (
-  .dst_rst_ni                 ( pwr_on_rst_ni              ),
-  .dst_clk_i                  ( clk_i                      ),
-  .dst_req_o                  ( dst_req                    ),
-  .dst_resp_i                 ( dst_resp                   ),
-  .async_data_slave_aw_wptr_i ( async_data_slave_aw_wptr_i ),   
-  .async_data_slave_aw_rptr_o ( async_data_slave_aw_rptr_o ),
-  .async_data_slave_aw_data_i ( async_data_slave_aw_data_i ),
-  .async_data_slave_w_wptr_i  ( async_data_slave_w_wptr_i  ),
-  .async_data_slave_w_rptr_o  ( async_data_slave_w_rptr_o  ),
-  .async_data_slave_w_data_i  ( async_data_slave_w_data_i  ),
-  .async_data_slave_ar_wptr_i ( async_data_slave_ar_wptr_i ),
-  .async_data_slave_ar_rptr_o ( async_data_slave_ar_rptr_o ),
-  .async_data_slave_ar_data_i ( async_data_slave_ar_data_i ),
-  .async_data_slave_b_wptr_o  ( async_data_slave_b_wptr_o  ),
-  .async_data_slave_b_rptr_i  ( async_data_slave_b_rptr_i  ),
-  .async_data_slave_b_data_o  ( async_data_slave_b_data_o  ),
-  .async_data_slave_r_wptr_o  ( async_data_slave_r_wptr_o  ),
-  .async_data_slave_r_rptr_i  ( async_data_slave_r_rptr_i  ),
-  .async_data_slave_r_data_o  ( async_data_slave_r_data_o  )  
+  .dst_rst_ni                       ( pwr_on_rst_ni              ),
+  .dst_clk_i                        ( clk_i                      ),
+  .dst_req_o                        ( dst_req                    ),
+  .dst_resp_i                       ( dst_resp                   ),
+  .async_data_slave_aw_wptr_i       ( async_data_slave_aw_wptr_i ),
+  .async_data_slave_aw_rptr_o       ( async_data_slave_aw_rptr_o ),
+  .async_data_slave_aw_data_i       ( async_data_slave_aw_data_i ),
+  .async_data_slave_w_wptr_i        ( async_data_slave_w_wptr_i  ),
+  .async_data_slave_w_rptr_o        ( async_data_slave_w_rptr_o  ),
+  .async_data_slave_w_data_i        ( async_data_slave_w_data_i  ),
+  .async_data_slave_ar_wptr_i       ( async_data_slave_ar_wptr_i ),
+  .async_data_slave_ar_rptr_o       ( async_data_slave_ar_rptr_o ),
+  .async_data_slave_ar_data_i       ( async_data_slave_ar_data_i ),
+  .async_data_slave_b_wptr_o        ( async_data_slave_b_wptr_o  ),
+  .async_data_slave_b_rptr_i        ( async_data_slave_b_rptr_i  ),
+  .async_data_slave_b_data_o        ( async_data_slave_b_data_o  ),
+  .async_data_slave_r_wptr_o        ( async_data_slave_r_wptr_o  ),
+  .async_data_slave_r_rptr_i        ( async_data_slave_r_rptr_i  ),
+  .async_data_slave_r_data_o        ( async_data_slave_r_data_o  )
 );
 
 // If the AXI ID width of the subordinate port does not match the one required, we interpose
@@ -1662,9 +1662,9 @@ cdc_fifo_gray_dst #(
   (* async *) .async_data_i ( async_cluster_events_data_i ),
   (* async *) .async_wptr_i ( async_cluster_events_wptr_i ),
   (* async *) .async_rptr_o ( async_cluster_events_rptr_o )
-); 
+);
 assign s_events_async = s_events_valid;
-  
+
 edge_propagator_tx ep_dma_pe_evt_i (
   .clk_i   ( clk_i              ),
   .rstn_i  ( rst_ni             ),
@@ -1672,7 +1672,7 @@ edge_propagator_tx ep_dma_pe_evt_i (
   .ack_i   ( dma_pe_evt_ack_i   ),
   .valid_o ( dma_pe_evt_valid_o )
 );
- 
+
 edge_propagator_tx ep_dma_pe_irq_i (
   .clk_i   ( clk_i              ),
   .rstn_i  ( rst_ni             ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -225,7 +225,7 @@ logic [Cfg.NumCores-1:0]                dbg_core_havereset;
 logic [Cfg.NumCores-1:0]                dbg_core_running;
 logic [Cfg.NumCores-1:0]                s_dbg_irq;
 logic                                   s_hwpe_en;
-logic                                   s_hwpe_sel;
+logic [$clog2(MAX_NUM_HWPES)-1:0]       s_hwpe_sel;
 
 logic                     fetch_en_synch;
 logic                     en_sa_boot_synch;
@@ -710,6 +710,7 @@ cluster_interconnect_wrap #(
 //***************************************************
 cluster_peripherals #(
   .NB_CORES       ( Cfg.NumCores      ),
+  .NB_HWPES       ( MAX_NUM_HWPES     ),
   .NB_MPERIPHS    ( Cfg.NumMstPeriphs ),
   .NB_CACHE_BANKS ( Cfg.iCacheNumBanks),
   .NB_SPERIPHS    ( Cfg.NumSlvPeriphs ),
@@ -1157,8 +1158,8 @@ endgenerate
 generate
   if(Cfg.HwpePresent) begin: hwpe_gen
     hwpe_subsystem #(
+      .HWPE_CFG      ( Cfg.HwpeCfg                      ),
       .N_CORES       ( Cfg.NumCores                     ),
-      .N_HWPES       ( 2                                ),
       .N_MASTER_PORT ( Cfg.HwpeNumPorts                 ),
       .ID_WIDTH      ( Cfg.NumCores + Cfg.NumMstPeriphs ),
       .DW            ( Cfg.HwpeNumPorts * DataWidth     ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -224,7 +224,8 @@ logic [Cfg.NumCores-1:0]                dbg_core_halted;
 logic [Cfg.NumCores-1:0]                dbg_core_havereset;
 logic [Cfg.NumCores-1:0]                dbg_core_running;
 logic [Cfg.NumCores-1:0]                s_dbg_irq;
-logic                               s_hwpe_en;
+logic                                   s_hwpe_en;
+logic                                   s_hwpe_sel;
 
 logic                     fetch_en_synch;
 logic                     en_sa_boot_synch;
@@ -782,6 +783,7 @@ cluster_peripherals #(
   .hwpe_cfg_master          ( s_hwpe_cfg_bus                    ),
   .hwpe_events_i            ( s_hwpe_remap_evt                  ),
   .hwpe_en_o                ( s_hwpe_en                         ),
+  .hwpe_sel_o               ( s_hwpe_sel                        ),
   .hci_ctrl_o               ( s_hci_ctrl                        ),
   .IC_ctrl_unit_bus_main    (  IC_ctrl_unit_bus_main            ),
   .IC_ctrl_unit_bus_pri     (  IC_ctrl_unit_bus_pri             ),
@@ -1156,13 +1158,18 @@ generate
   if(Cfg.HwpePresent) begin: hwpe_gen
     hwpe_subsystem #(
       .N_CORES       ( Cfg.NumCores                     ),
+      .N_HWPES       ( 2                                ),
       .N_MASTER_PORT ( Cfg.HwpeNumPorts                 ),
-      .ID_WIDTH      ( Cfg.NumCores + Cfg.NumMstPeriphs )
+      .ID_WIDTH      ( Cfg.NumCores + Cfg.NumMstPeriphs ),
+      .DW            ( Cfg.HwpeNumPorts * DataWidth     ),
+      .AW            ( AddrWidth                        ),
+      .OW            ( 1                                )
     ) hwpe_subsystem_i (
       .clk               ( clk_i          ),
       .rst_n             ( rst_ni         ),
       .test_mode         ( test_mode_i    ),
       .hwpe_en_i         ( s_hwpe_en      ),
+      .hwpe_sel_i        ( s_hwpe_sel     ),
       .hwpe_xbar_master  ( s_hci_hwpe [0] ),
       .hwpe_cfg_slave    ( s_hwpe_cfg_bus ),
       .evt_o             ( s_hwpe_evt     ),

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -33,7 +33,7 @@ module pulp_cluster_tb;
   logic s_clk;
   logic s_rstn;
   logic s_rstn_cl;
-  
+
   localparam time SYS_TCK  = 8ns;
   localparam time SYS_TA   = 2ns;
   localparam time SYS_TT   = SYS_TCK - 2ns;
@@ -45,7 +45,7 @@ module pulp_cluster_tb;
       .clk_o  ( s_clk  ),
       .rst_no ( s_rstn )
   );
-   
+
   localparam AxiAw  = 48;
   localparam AxiDw  = 64;
   localparam AxiIw  = 6;
@@ -65,7 +65,7 @@ module pulp_cluster_tb;
   localparam bit[AxiAw-1:0] L2Size          = 'h10000000;
   localparam bit[AxiAw-1:0] BootAddr        = L2BaseAddr + 'h8080;
   localparam bit[AxiAw-1:0] ClustReturnInt  = 'h50200100;
-   
+
   typedef logic [AxiAw-1:0]    axi_addr_t;
   typedef logic [AxiDw-1:0]    axi_data_t;
   typedef logic [AxiDw/8-1:0]  axi_strb_t;
@@ -86,20 +86,20 @@ module pulp_cluster_tb;
   `AXI_TYPEDEF_AR_CHAN_T(ar_m_chan_t, axi_addr_t, axi_m_id_t, axi_user_t)
   `AXI_TYPEDEF_R_CHAN_T(r_m_chan_t, axi_data_t, axi_m_id_t, axi_user_t)
   `AXI_TYPEDEF_REQ_T(axi_m_req_t, aw_m_chan_t, w_chan_t, ar_m_chan_t)
-  `AXI_TYPEDEF_RESP_T(axi_m_resp_t, b_m_chan_t, r_m_chan_t)   
+  `AXI_TYPEDEF_RESP_T(axi_m_resp_t, b_m_chan_t, r_m_chan_t)
 
   typedef logic [AxiAw-1:0] addr_t;
-  typedef logic [AxiDw-1:0] data_t;   
+  typedef logic [AxiDw-1:0] data_t;
   data_t memory [bit [31:0]];
   int sections  [bit [31:0]];
-   
+
   string        binary ;
-   
+
   logic s_cluster_en_sa_boot ;
   logic s_cluster_fetch_en   ;
   logic s_cluster_eoc        ;
   logic s_cluster_busy       ;
-   
+
   AXI_BUS #(
       .AXI_ADDR_WIDTH( AxiAw    ),
       .AXI_DATA_WIDTH( AxiDw    ),
@@ -140,10 +140,10 @@ module pulp_cluster_tb;
    // Behavioural slaves
    axi_m_req_t  axi_memreq;
    axi_m_resp_t axi_memrsp;
-   
+
   `AXI_ASSIGN_TO_REQ(axi_memreq, axi_master[1])
   `AXI_ASSIGN_FROM_RESP(axi_master[1], axi_memrsp)
-   
+
   axi_sim_mem #(
     .AddrWidth ( AxiAw        ),
     .DataWidth ( AxiDw        ),
@@ -152,7 +152,7 @@ module pulp_cluster_tb;
     .axi_req_t ( axi_m_req_t  ),
     .axi_rsp_t ( axi_m_resp_t ),
     .ApplDelay ( SYS_TA       ),
-    .AcqDelay  ( SYS_TT       )    
+    .AcqDelay  ( SYS_TT       )
   ) sim_mem (
      .clk_i     ( s_clk      ),
      .rst_ni    ( s_rstn     ),
@@ -171,7 +171,7 @@ module pulp_cluster_tb;
      .test_i ( '0            ),
      .uart   ( axi_master[0] )
   );
-   
+
   // XBAR
   localparam int unsigned NumRules = NSlv+1;
 
@@ -247,7 +247,7 @@ module pulp_cluster_tb;
       .slv    ( axi_master[2]          ),
       .mst    ( soc_to_cluster_axi_bus )
     );
-   
+
   axi_cdc_src_intf   #(
     .AXI_ADDR_WIDTH ( AxiAw   ),
     .AXI_DATA_WIDTH ( AxiDw   ),
@@ -260,7 +260,7 @@ module pulp_cluster_tb;
       .src        ( soc_to_cluster_axi_bus       ),
       .dst        ( async_soc_to_cluster_axi_bus )
       );
-   
+
   axi_cdc_dst_intf   #(
     .AXI_ADDR_WIDTH ( AxiAw ),
     .AXI_DATA_WIDTH ( AxiDw ),
@@ -347,7 +347,7 @@ module pulp_cluster_tb;
 
     .dma_pe_evt_ack_i            ( '1                                   ),
     .dma_pe_evt_valid_o          (                                      ),
-                                    
+
     .dma_pe_irq_ack_i            ( 1'b1                                 ),
     .dma_pe_irq_valid_o          (                                      ),
 
@@ -454,10 +454,10 @@ module pulp_cluster_tb;
   initial begin
 
    assign s_cluster_en_sa_boot = 1'b0;
-   assign s_cluster_fetch_en = 1'b0;  
+   assign s_cluster_fetch_en = 1'b0;
    axi_master_drv.reset_master();
    axi_master_drv.reset_slave();
-     
+
    @(posedge s_rstn);
    @(posedge s_clk);
 
@@ -465,40 +465,40 @@ module pulp_cluster_tb;
      $display("[TB] Testing %s", binary);
 
    load_binary(binary);
-     
+
    foreach (sections[addr]) begin
       $display("[TB] Writing %h with %0d words", addr << 3, sections[addr]); // word = 8 bytes here
       for (int i = 0; i < sections[addr]; i++) begin
-         
+
         aw_beat.ax_addr  = ( addr << 3 ) + ( i * 8 );
         aw_beat.ax_len   = '0;
         aw_beat.ax_burst = axi_pkg::BURST_INCR;
         aw_beat.ax_size  = 4'h3;
-        
+
         w_beat.w_data = memory[addr + i][63:0];
         w_beat.w_strb = '1;
         w_beat.w_last = '1;
- 
+
         axi_master_drv.send_aw(aw_beat);
         axi_master_drv.send_w(w_beat);
         @(posedge s_clk);
         axi_master_drv.recv_b(b_beat);
 
       end // for (int i = 0; i < sections[addr]; i++)
-      $display("[TB] Completed\n");      
-   end 
+      $display("[TB] Completed\n");
+   end
 
    $display("[TB] Initialize ret_val\n");
-     
+
    aw_beat.ax_addr  = 32'h1A10_40A0;
    aw_beat.ax_len   = '0;
    aw_beat.ax_burst = axi_pkg::BURST_INCR;
    aw_beat.ax_size  = 4'h3;
-   
+
    w_beat.w_data = '0;
    w_beat.w_strb = '1;
    w_beat.w_last = '1;
- 
+
    axi_master_drv.send_aw(aw_beat);
    axi_master_drv.send_w(w_beat);
    @(posedge s_clk);
@@ -544,7 +544,7 @@ module pulp_cluster_tb;
    ret_val = r_beat.r_data;
 
    $display("[TB] Received ret_val: %d\n", ret_val[30:0]);
-     
+
    if(ret_val[30:0]==0) begin
      $display("[TB] Test passed\n");
      $finish;
@@ -553,6 +553,6 @@ module pulp_cluster_tb;
    end
 
   end
-   
-   
+
+
 endmodule : pulp_cluster_tb

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -289,6 +289,7 @@ module pulp_cluster_tb;
     TcdmSize: 256*1024,
     TcdmNumBank: 16,
     HwpePresent: 1,
+    HwpeCfg: '{NumHwpes: 2, HwpeList: {NEUREKA, REDMULE}},
     HwpeNumPorts: 9,
     iCacheNumBanks: 2,
     iCacheNumLines: 1,


### PR DESCRIPTION
Add the two HWPEs in the HWPE subsystem and use a static selection signal to choose between them.
Some important points are:

- Arrays of interfaces have been used to make the number of HWPEs a parameter
- Currently the peripherals support a single selection bit (https://github.com/pulp-platform/cluster_peripherals/pull/5), if we want to parametrize the whole design this can be discussed, otherwise the HWPE is currently hardcoded at 2 HWPEs when instantiated.