### PR TITLE
fix printing from all cores

### DIFF
--- a/tb/mock_uart.sv
+++ b/tb/mock_uart.sv
@@ -60,7 +60,7 @@ module mock_uart  #(
 
     function void uart_tx(byte ch);
         if(ch==8'h0A) begin
-          $display("[TB UART] %s", stringa);        
+          $display("[TB UART %2d] %s", UART_IDX, stringa);        
           charnum = 0;
           stringa = '0;
         end else begin

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -164,10 +164,12 @@ module pulp_cluster_tb;
   );
 
   mock_uart_axi #(
-   .AxiIw ( AxiIwMst ),
-   .AxiAw ( AxiAw    ),
-   .AxiDw ( AxiDw    ),
-   .AxiUw ( AxiUw    )
+   .AxiIw   ( AxiIwMst      ),
+   .AxiAw   ( AxiAw         ),
+   .AxiDw   ( AxiDw         ),
+   .AxiUw   ( AxiUw         ),
+   .N_CORES ( 8             ),
+   .BaseAddr( 32'h4000_0000 )
   ) i_mock_uart (
      .clk_i  ( s_clk         ),
      .rst_ni ( s_rstn        ),


### PR DESCRIPTION
Small changes to have one `mock_uart` per core, so that each core can use `printf`. Before, only print statements from cores 0 and 4 were picked up.