### PR TITLE
Fixes for HWPE subsystem

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -108,7 +108,7 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: 38fc2a7eea7978df52434e66ee04a40788fd86b7
+    revision: aed9005c761827c6cbff2ea9a15f9cc37acd1169
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -30,7 +30,7 @@ dependencies:
   cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: e863f576699815b38cc9d80dbdede8ed5efd5991 } # `michaero/safety-island-clic` branch
   ibex:                   { git: "https://github.com/pulp-platform/ibex.git", rev: "pulpissimo-v6.1.2" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", rev: 74426dee36f28ae1c02f7635cf844a0156145320 } # branch: yt/bump-clkgating
-  hci:                    { git: "https://github.com/pulp-platform/hci.git", rev: 38fc2a7 } # branch: lg/ecc_rebase_v2.1.1
+  hci:                    { git: "https://github.com/pulp-platform/hci.git", rev: aed9005 } # branch: lg/ecc_fix_no_hwpe
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.4  }
   redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: 49e714b97a19a7aaddf064ae2757c8f02d1f62dc } # branch: astral-v0
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", rev: astral-v1.0 }

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ sw-clean:
 
 ## Clone pulp-runtime as SW stack
 PULP_RUNTIME_REMOTE ?= https://github.com/pulp-platform/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 272b0da # branch: upstream-features
+PULP_RUNTIME_COMMIT ?= b3c239c # branch: lg/upstream
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,6 @@ include bender-sim.mk
 scripts/compile.tcl: | Bender.lock
 	$(call generate_vsim, $@, $(common_defs) $(common_targs) $(sim_defs) $(sim_targs),..)
 	echo 'vlog "$(realpath $(ROOT_DIR))/tb/dpi/elfloader.cpp" -ccflags "-std=c++11"' >> $@
-	echo 'vopt +permissive -suppress 3053 -suppress 8885 +UVM_NO_RELNOTES $(top_level) -o $(top_level)_optimized' >> $@
 
 include bender-synth.mk
 scripts/synth-compile.tcl: | Bender.lock

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/pulp-platform/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= 799c996 # branch: upstream-features
+REGRESSION_TESTS_COMMIT ?= d43cb0d # branch: lg/upstream
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -44,18 +44,6 @@ module hwpe_subsystem
   localparam int unsigned EW = HCI_HWPE_SIZE.EW;
   localparam int unsigned EHW = HCI_HWPE_SIZE.EHW;
 
-  // TEMP: localparam used by softex since it doesn't support yet ECC-HCI interface
-  localparam hci_package::hci_size_parameter_t `HCI_SIZE_PARAM(tcdm_softex) = '{
-    DW:  DW,
-    AW:  AW,
-    BW:  DEFAULT_BW,
-    UW:  DEFAULT_UW,
-    IW:  DEFAULT_IW,
-    EW:  DEFAULT_EW,
-    EHW: DEFAULT_EHW
-  };
-  `HCI_INTF(tcdm_softex, clk);
-
   localparam int unsigned N_HWPES = HWPE_CFG.NumHwpes;
   localparam int unsigned HWPE_SEL_BITS = (N_HWPES > 1) ? $clog2(N_HWPES) : 1;
 
@@ -149,27 +137,14 @@ module hwpe_subsystem
 
       softex_top #(
         .N_CORES    ( N_CORES           ),
-        .`HCI_SIZE_PARAM(Tcdm) ( `HCI_SIZE_PARAM(tcdm_softex) )
+        .`HCI_SIZE_PARAM(Tcdm) ( HCI_HWPE_SIZE )
       ) i_softex (
         .clk_i  ( hwpe_clk[i] ),
         .rst_ni ( rst_n       ),
         .busy_o ( busy[i]     ),
         .evt_o  ( evt[i]      ),
-        .tcdm   ( tcdm_softex ),
+        .tcdm   ( tcdm[i]     ),
         .periph ( periph[i]   )
-      );
-
-      // TEMP: softex doesn't yet support ECC-HCI internally
-      hci_ecc_enc #(
-        .`HCI_SIZE_PARAM(tcdm_target)    ( `HCI_SIZE_PARAM(tcdm_softex) ),
-        .`HCI_SIZE_PARAM(tcdm_initiator) ( HCI_HWPE_SIZE )
-      ) i_ecc_softex_enc (
-        .r_data_single_err_o (  ),
-        .r_data_multi_err_o  (  ),
-        .r_meta_single_err_o (  ),
-        .r_meta_multi_err_o  (  ),
-        .tcdm_target         ( tcdm_softex ),
-        .tcdm_initiator      ( tcdm[i]     )
       );
 
     end

--- a/rtl/hwpe_subsystem.sv
+++ b/rtl/hwpe_subsystem.sv
@@ -57,6 +57,7 @@ module hwpe_subsystem
   `HCI_INTF(tcdm_softex, clk);
 
   localparam int unsigned N_HWPES = HWPE_CFG.NumHwpes;
+  localparam int unsigned HWPE_SEL_BITS = (N_HWPES > 1) ? $clog2(N_HWPES) : 1;
 
   logic [N_HWPES-1:0] busy;
   logic [N_HWPES-1:0][N_CORES-1:0][1:0] evt;
@@ -64,9 +65,9 @@ module hwpe_subsystem
   logic [N_HWPES-1:0] hwpe_clk;
   logic [N_HWPES-1:0] hwpe_en_int;
 
-  logic [$clog2(N_HWPES)-1:0] hwpe_sel_int;
+  logic [HWPE_SEL_BITS-1:0] hwpe_sel_int;
 
-  assign hwpe_sel_int = hwpe_sel_i[0+:$clog2(N_HWPES)];
+  assign hwpe_sel_int = hwpe_sel_i[HWPE_SEL_BITS-1:0];
 
   hwpe_ctrl_intf_periph #(
     .ID_WIDTH ( ID_WIDTH )

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -310,7 +310,7 @@ localparam hci_package::hci_size_parameter_t HciHwpeSizeParam = '{
   BW:  DEFAULT_BW,
   UW:  DEFAULT_UW,
   IW:  DEFAULT_IW,
-  EW:  HWPEParityWidth,
+  EW:  (Cfg.ECCInterco) ? HWPEParityWidth : DEFAULT_EW,
   EHW: DEFAULT_EHW
 };
 /* logarithmic and peripheral interconnect interfaces */
@@ -419,21 +419,21 @@ snitch_icache_pkg::icache_l1_events_t                    s_icache_l1_events;
 localparam TCDM_ID_WIDTH = Cfg.NumCores + Cfg.DmaNumPlugs + 4 + Cfg.HwpeNumPorts;
 localparam hci_package::hci_size_parameter_t HciMemSizeParam = '{
   DW:  DataWidth,
-  AW:  AddrMemWidth+2,
+  AW:  AddrMemWidth+2, // AddrMemWidth is word-wise, +2 for byte-wise
   BW:  8,
   UW:  DEFAULT_UW,
   IW:  TCDM_ID_WIDTH,
-  EW:  ParityWidth+MetaParityWidth,
+  EW:  (Cfg.ECCInterco) ? ParityWidth+MetaParityWidth : DEFAULT_EW,
   EHW: DEFAULT_EHW
 };
 
 // log interconnect -> TCDM memory banks (SRAM)
 hci_core_intf #(
-  .AW ( AddrMemWidth+2 ), // AddrMemWidth is word-wise, +2 for byte-wise
-  .DW ( DataWidth      ),
-  .BW ( 8              ),
-  .IW ( TCDM_ID_WIDTH  ),
-  .EW ( ParityWidth+MetaParityWidth )
+  .DW ( HciMemSizeParam.DW ),
+  .AW ( HciMemSizeParam.AW ),
+  .BW ( HciMemSizeParam.BW ),
+  .IW ( HciMemSizeParam.IW ),
+  .EW ( HciMemSizeParam.EW )
 `ifndef SYNTHESIS
   ,
   .WAIVE_RSP3_ASSERT ( 1'b1 ),


### PR DESCRIPTION
This PR introduces some modifications/fixes to the HWPE subsystem.

In particular:

1. It fixes the Astral-based pulp cluster in the following non-default scenarios:
    - N_HWPE = 1
    - N_HWPE = 0 (HwpePresent=0)
    - ECCInterco = 0

2. It introduces `softex` version that supports ECC-HCI

In addition, it also removes a duplicated call to `vopt` in the Makefile