### PR TITLE
Replaced axi_dw_converter_intf instance in pulp_cluster.sv with axi_dw_converter

### DIFF
--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1745,13 +1745,12 @@ if (Cfg.AxiDataInWidth != Cfg.AxiDataOutWidth) begin
   `AXI_ASSIGN_REQ_STRUCT(s_data_slave_32_req,dst_remap_req)
   `AXI_ASSIGN_RESP_STRUCT(dst_remap_resp,s_data_slave_32_resp)
 
-  axi_dw_converter_intf #(
-    .AXI_ID_WIDTH            ( AxiIdInWidth         ),
-    .AXI_ADDR_WIDTH          ( Cfg.AxiAddrWidth     ),
-    .AXI_SLV_PORT_DATA_WIDTH ( Cfg.AxiDataInWidth   ),
-    .AXI_MST_PORT_DATA_WIDTH ( Cfg.AxiDataOutWidth  ),
-    .AXI_USER_WIDTH          ( Cfg.AxiUserWidth     ),
-    .AXI_MAX_READS           ( 1                    ),
+  axi_dw_converter #(
+    .AxiIdWidth            ( AxiIdInWidth         ),
+    .AxiAddrWidth          ( Cfg.AxiAddrWidth     ),
+    .AxiSlvPortDataWidth   ( Cfg.AxiDataInWidth   ),
+    .AxiMstPortDataWidth   ( Cfg.AxiDataOutWidth  ),
+    .AxiMaxReads           ( 1                    ),
     .aw_chan_t               ( s2c_in_int_aw_chan_t ),
     .mst_w_chan_t            ( c2s_w_chan_t         ),
     .slv_w_chan_t            ( s2c_in_int_w_chan_t  ),


### PR DESCRIPTION
In the current PULP cluster implementation, the [AXI DW converter](https://github.com/pulp-platform/pulp_cluster/blob/master/rtl/pulp_cluster.sv#L1748-L1773) uses the [struct data types version](https://github.com/pulp-platform/axi/blob/master/src/axi_dw_converter.sv#L18-L44) but with the all capital snake type parameters and name of the [interface version](https://github.com/pulp-platform/axi/blob/master/src/axi_dw_converter.sv#L118-L125). This PR fixes this issue,

@yvantor 