### PR TITLE
Makefile: Bump `regression_tests` and `pulp-runtime` for carfield target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/pulp-platform/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= 26d7629 # branch: lg/upstream
+REGRESSION_TESTS_COMMIT ?= dd7ef99 # branch: lg/upstream
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@


### PR DESCRIPTION
* Adapt Carfield's DMR test to 8 cores (`regression_tests`)
* Set default number of cores for Carfield's cluster to 8 (`pulp-runtime`)