### PR TITLE
Minor Fixes/Addition to Submodules & Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ sw-clean:
 
 ## Clone pulp-runtime as SW stack
 PULP_RUNTIME_REMOTE ?= https://github.com/pulp-platform/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 1e3bccf # branch: lg/upstream
+PULP_RUNTIME_COMMIT ?= f10670b # branch: lg/upstream
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@
@@ -91,7 +91,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/pulp-platform/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= 6e93422 # branch: lg/upstream
+REGRESSION_TESTS_COMMIT ?= 7fa307d # branch: lg/upstream
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@

--- a/scripts/run_and_exit.tcl
+++ b/scripts/run_and_exit.tcl
@@ -13,8 +13,6 @@ if {![info exists VSIM]} {
 
 $VSIM +permissive -suppress 3053 -suppress 8885 -suppress 12130 -suppress 7077 -lib $VSIM_PATH/work +APP=./build/test/test +notimingchecks +nospecify -t 1ps pulp_cluster_tb_optimized +permissive-off ++./build/test/test
 
-add log -r /*
-
 proc run_and_exit {} {
     run -all
     quit -code [examine -radix decimal sim:/pulp_cluster_tb/ret_val(30:0)]


### PR DESCRIPTION
This PR introduces some minor fixes/additions in the "submodules" and removes what I believe is unnecessary logging when QuestaSim runs in command line mode. The latter is primarily useful for running regression tests, as it reduces execution time and prevents the creation of unnecessary log files. If you believe it should stay, I can easily remove that commit from the PR.

For references about "submodules" changes:
- Pulp runtime: [commit](https://github.com/pulp-platform/pulp-runtime/commit/f10670b427c5ff9eb3c25e2b9c97e96a18a0cdb2) that introduces UART drivers when it is a host peripheral (useful for platforms like Carfield and Astral)
- Regression test: [Remove an unintended file](https://github.com/pulp-platform/regression_tests/commit/9de83fa5a6662ee085607e485a23e6ac4af5ecc6) and [bump submodule for NEureka for small fixes](https://github.com/pulp-platform/regression_tests/commit/7fa307d24daf38a26a81013f677b4b1e422d76e8)