### PR TITLE
Remove cluster_id info from core demux.

### DIFF
--- a/rtl/core_demux_wrap.sv
+++ b/rtl/core_demux_wrap.sv
@@ -14,7 +14,6 @@ module core_demux_wrap #(
   input  logic test_en_i                     ,
   input  logic clk_en_i                      ,
   input  logic [3:0] base_addr_i             ,
-  input  logic [5:0] cluster_id_i            ,
   output logic [NumExtPerf-1:0] ext_perf_o   ,
   input  core_data_req_t core_data_req_i     ,
   output core_data_rsp_t core_data_rsp_o     ,
@@ -109,8 +108,7 @@ data_periph_demux #(
   .perf_l2_ld_o       (  ext_perf_o [0]             ),
   .perf_l2_st_o       (  ext_perf_o [1]             ),
   .perf_l2_ld_cyc_o   (  ext_perf_o [2]             ),
-  .perf_l2_st_cyc_o   (  ext_perf_o [3]             ),
-  .CLUSTER_ID         (  cluster_id_i               )
+  .perf_l2_st_cyc_o   (  ext_perf_o [3]             )
 );
 
 assign ext_perf_o[4] = '0;

--- a/rtl/data_periph_demux.sv
+++ b/rtl/data_periph_demux.sv
@@ -78,9 +78,7 @@ module data_periph_demux
     output logic                         perf_l2_ld_o, // nr of L2 loads
     output logic                         perf_l2_st_o, // nr of L2 stores
     output logic                         perf_l2_ld_cyc_o, // cycles used for L2 loads
-    output logic                         perf_l2_st_cyc_o,  // cycles used for L2 stores
-    
-    input  logic [5:0]                   CLUSTER_ID
+    output logic                         perf_l2_st_cyc_o  // cycles used for L2 stores
 );
    
    logic [10:0] CLUSTER_ALIAS_BASE_11;
@@ -135,9 +133,9 @@ module data_periph_demux
 
   always_comb
   begin
-    TCDM_RW          = {base_addr_i, 8'h00} + (CLUSTER_ID << 2) + 0;
-    TCDM_TS          = {base_addr_i, 8'h00} + (CLUSTER_ID << 2) + 1;
-    DEM_PER          = {base_addr_i, 8'h00} + (CLUSTER_ID << 2) + 2;
+    TCDM_RW          = {base_addr_i, 8'h00} + 0;
+    TCDM_TS          = {base_addr_i, 8'h00} + 1;
+    DEM_PER          = {base_addr_i, 8'h00} + 2;
   end
  
  

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1027,7 +1027,6 @@ generate
       .test_en_i           ( test_mode_i           ),
       .clk_en_i            ( clk_core_en[i]        ),
       .base_addr_i         ( base_addr_i           ),
-      .cluster_id_i        ( cluster_id_i          ),
       .ext_perf_o          ( ext_perf[i]           ),
       .core_data_req_i     ( demux_data_req[i]     ),
       .core_data_rsp_o     ( demux_data_rsp[i]     ),


### PR DESCRIPTION
I propose to remove the cluster_id information from the core_demux because it is used differently from the other IPs that need it (i.e. cluster_bus_wrap and xbar_pe). Essentially it is recomputing the most significant 12-bits of the pulp_cluster base address ignoring the fact that the offset given by the id is already provided from the outside.
Let me know what you think, this is giving me a bit of urticaria because in general it looks like this cluster_id thing has been developed by different people (working on both hardware and software) who did not communicate much, so it is quite confuring and bothering. Happy to discuss ways to make it cleaner, but for now I am opening this PR.